### PR TITLE
Expand configurable themes

### DIFF
--- a/examples/config/config.toml
+++ b/examples/config/config.toml
@@ -74,7 +74,11 @@ skip_istio = true
 # debug_log_dir = "/tmp"
 
 # [tui]
-# theme = "kanagawa-dragon"
+# theme = "kanagawa"
+#
+# Shipped themes include: default, forest, kanagawa, kanagawa_dragon,
+# gruvbox, dracula, catppuccin_mocha, tokyo_night, nord, mono, ocean.
+# See examples/config/themes.toml for a complete custom [themes.<name>] example.
 
 # [store]
 # capacity = 1_000_000

--- a/examples/config/config.toml
+++ b/examples/config/config.toml
@@ -11,8 +11,9 @@ profile = "dev"
 
 # --- profiles ----------------------------------------------------------------
 #
-# Each [[profiles.<name>.producers]] entry adds one producer to the bundle.
-# `type` is one of: demo, file, docker, kubernetes.
+# Each profile can set `theme = "<name>"` to override [tui].theme while that
+# profile is active. Each [[profiles.<name>.producers]] entry adds one producer
+# to the bundle. `type` is one of: demo, file, docker, kubernetes.
 #   - demo is repeatable.
 #   - docker may appear at most once per profile (a second is a config error).
 #   - kubernetes can appear multiple times with different namespaces.
@@ -23,6 +24,9 @@ profile = "dev"
 # — no SourceFound, no SourceLost, no log entries reach fml.
 
 # Local development: a synthetic feed plus a tailed file.
+[profiles.dev]
+theme = "kanagawa"
+
 [[profiles.dev.producers]]
 type = "demo"
 
@@ -31,12 +35,18 @@ type = "file"
 file = "/var/log/app.log"
 
 # Staging: docker producer with the istio sidecar filtered out.
+[profiles.staging]
+theme = "tokyo_night"
+
 [[profiles.staging.producers]]
 type = "docker"
 skip_istio = true
 
 # Production: two kube namespaces; team-a drops debug-prefixed pods, team-b
 # blocks anything matching `_postgres_` in the pod or container name.
+[profiles.prod]
+theme = "nord"
+
 [[profiles.prod.producers]]
 type = "kubernetes"
 namespace = "team-a"

--- a/examples/config/themes.toml
+++ b/examples/config/themes.toml
@@ -11,6 +11,10 @@ theme = "kanagawa"
 
 # To use the custom theme below instead, set:
 # theme = "solarized_dark"
+#
+# Profiles can also override the theme while active:
+# [profiles.dev]
+# theme = "solarized_dark"
 
 [themes.solarized_dark]
 background = "#002B36"

--- a/examples/config/themes.toml
+++ b/examples/config/themes.toml
@@ -1,0 +1,37 @@
+# Example fml theme config.
+#
+# Copy this file to $XDG_CONFIG_HOME/fml/config.toml or .config/fml/config.toml
+# and choose either a shipped theme or the custom theme below.
+
+[tui]
+# Shipped themes include:
+# default, forest, kanagawa, kanagawa_dragon, gruvbox, dracula,
+# catppuccin_mocha, tokyo_night, nord, mono, ocean.
+theme = "kanagawa"
+
+# To use the custom theme below instead, set:
+# theme = "solarized_dark"
+
+[themes.solarized_dark]
+background = "#002B36"
+border_unfocused_fg = "#586E75"
+primary_accent_fg = "#B58900"
+secondary_accent_fg = "#268BD2"
+source_selector_producer_fg = "#B58900"
+source_selector_group_fg = "#2AA198"
+source_selector_source_fg = "#93A1A1"
+log_selected_bg = "#073642"
+log_selected_modifier = "BOLD"
+log_match_fg = "#CB4B16"
+log_match_style = "color"
+log_match_bold = true
+status_dim = true
+
+[themes.solarized_dark.log_level]
+default_fg = "#93A1A1"
+trace_fg = "#586E75"
+debug_fg = "#268BD2"
+info_fg = "#859900"
+warn_fg = "#B58900"
+error_fg = "#DC322F"
+fatal_fg = "#D33682"

--- a/fml/src/cli.rs
+++ b/fml/src/cli.rs
@@ -171,9 +171,13 @@ mod tests {
             profile: Some(name.to_string()),
             ..Config::default()
         };
-        config
-            .profiles
-            .insert(name.to_string(), ProfileConfig { producers });
+        config.profiles.insert(
+            name.to_string(),
+            ProfileConfig {
+                theme: None,
+                producers,
+            },
+        );
         config
     }
 
@@ -307,6 +311,7 @@ mod tests {
         config.profiles.insert(
             "prod".to_string(),
             ProfileConfig {
+                theme: None,
                 producers: vec![ProducerConfig::Docker {
                     block: SourceBlockConfig::default(),
                 }],

--- a/fml/src/config.rs
+++ b/fml/src/config.rs
@@ -153,6 +153,17 @@ impl Config {
         Ok(Some(profile))
     }
 
+    /// Apply the active profile's non-producer overrides to this config.
+    pub fn apply_profile_overrides(&mut self, name: Option<&str>) -> Result<(), FmlError> {
+        let Some(profile) = self.resolve_profile(name)? else {
+            return Ok(());
+        };
+        if let Some(theme) = &profile.theme {
+            self.tui.theme = theme.clone();
+        }
+        Ok(())
+    }
+
     fn load_with_config_dir(config_dir: &str) -> Result<Self, FmlError> {
         let s = config::Config::builder()
             .add_source(File::with_name(&format!("{config_dir}/config")).required(false))
@@ -475,6 +486,9 @@ mod tests {
             r#"
             profile = "dev"
 
+            [profiles.dev]
+            theme = "kanagawa"
+
             [[profiles.dev.producers]]
             type = "demo"
 
@@ -489,7 +503,30 @@ mod tests {
         let config = Config::load_with_config_dir(dir.path().to_str().unwrap()).unwrap();
         assert_eq!(config.profile.as_deref(), Some("dev"));
         let profile = config.resolve_profile(Some("dev")).unwrap().unwrap();
+        assert_eq!(profile.theme.as_deref(), Some("kanagawa"));
         assert_eq!(profile.producers.len(), 2);
+    }
+
+    #[test]
+    #[serial]
+    fn active_profile_applies_theme_override() {
+        let mut config = Config {
+            profile: Some("dev".to_string()),
+            ..Config::default()
+        };
+        config.profiles.insert(
+            "dev".to_string(),
+            ProfileConfig {
+                theme: Some("nord".to_string()),
+                producers: vec![ProducerConfig::Demo],
+            },
+        );
+
+        config
+            .apply_profile_overrides(config.profile.clone().as_deref())
+            .unwrap();
+
+        assert_eq!(config.tui.theme, "nord");
     }
 
     #[test]

--- a/fml/src/config.rs
+++ b/fml/src/config.rs
@@ -48,6 +48,10 @@ pub struct Config {
     #[serde(default)]
     pub tui: tui::TuiConfig,
 
+    /// User-defined named themes selectable via `tui.theme`.
+    #[serde(default)]
+    pub themes: BTreeMap<String, tui::ThemeConfig>,
+
     /// Store capacity and ingest speed settings
     #[serde(default)]
     pub store: store::StoreConfig,
@@ -76,6 +80,7 @@ impl Default for Config {
             debug_log_dir: default_debug_log_dir(),
             default_log_level: default_log_level(),
             tui: tui::TuiConfig::default(),
+            themes: BTreeMap::new(),
             store: store::StoreConfig::default(),
             search: search::SearchConfig::default(),
             profile: None,
@@ -156,6 +161,7 @@ impl Config {
             .build()?;
 
         let config: Self = s.try_deserialize()?;
+        themes::validate_user_themes(&config.themes)?;
 
         Ok(config)
     }
@@ -165,6 +171,7 @@ impl Config {
 mod tests {
     use std::fs;
 
+    use ratatui::style::Color;
     use serial_test::serial;
 
     use super::*;
@@ -301,6 +308,71 @@ mod tests {
         let config = Config::load_with_config_dir(dir.path().to_str().unwrap()).unwrap();
 
         assert_eq!(config.search.fuzzy_matcher, FuzzyMatcherKind::Frizbee);
+    }
+
+    #[test]
+    #[serial]
+    fn load_with_config_dir_reads_user_defined_theme() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("config.toml"),
+            r##"
+            [tui]
+            theme = "solarized"
+
+            [themes.solarized]
+            background = "#002B36"
+            border_unfocused_fg = "#586E75"
+            primary_accent_fg = "#B58900"
+            secondary_accent_fg = "#268BD2"
+            source_selector_producer_fg = "#B58900"
+            source_selector_group_fg = "#2AA198"
+            source_selector_source_fg = "#93A1A1"
+            log_selected_bg = "#073642"
+            log_selected_modifier = "BOLD"
+            log_match_fg = "#CB4B16"
+            log_match_style = "color"
+            log_match_bold = true
+            status_dim = true
+
+            [themes.solarized.log_level]
+            default_fg = "#93A1A1"
+            trace_fg = "#586E75"
+            debug_fg = "#268BD2"
+            info_fg = "#859900"
+            warn_fg = "#B58900"
+            error_fg = "#DC322F"
+            fatal_fg = "#D33682"
+            "##,
+        )
+        .unwrap();
+
+        let config = Config::load_with_config_dir(dir.path().to_str().unwrap()).unwrap();
+        let resolved = config.tui.resolved_theme_with(&config.themes).unwrap();
+
+        assert_eq!(resolved.background, Some(Color::Rgb(0x00, 0x2B, 0x36)));
+        assert_eq!(resolved.primary_accent_fg, Color::Rgb(0xB5, 0x89, 0x00));
+    }
+
+    #[test]
+    #[serial]
+    fn load_with_config_dir_rejects_user_theme_builtin_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("config.toml"),
+            r##"
+            [themes.forest]
+            background = "#002B36"
+            "##,
+        )
+        .unwrap();
+
+        let err = Config::load_with_config_dir(dir.path().to_str().unwrap()).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("collides with a built-in theme name")
+        );
     }
 
     #[test]

--- a/fml/src/config/producer.rs
+++ b/fml/src/config/producer.rs
@@ -82,6 +82,10 @@ impl From<&ProducerConfig> for ProducerSpec {
 /// A named startup bundle of producers.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProfileConfig {
+    /// Optional TUI theme override applied when this profile is active.
+    #[serde(default)]
+    pub theme: Option<String>,
+
     #[serde(default)]
     pub producers: Vec<ProducerConfig>,
 }
@@ -180,6 +184,7 @@ mod tests {
     #[test]
     fn profile_validate_allows_multiple_demo_entries() {
         let profile = ProfileConfig {
+            theme: None,
             producers: vec![ProducerConfig::Demo, ProducerConfig::Demo],
         };
         profile.validate("p").unwrap();
@@ -188,6 +193,7 @@ mod tests {
     #[test]
     fn profile_validate_rejects_multiple_docker_entries() {
         let profile = ProfileConfig {
+            theme: None,
             producers: vec![
                 ProducerConfig::Docker {
                     block: SourceBlockConfig::default(),
@@ -204,6 +210,7 @@ mod tests {
     #[test]
     fn profile_validate_allows_multiple_kube_namespaces() {
         let profile = ProfileConfig {
+            theme: None,
             producers: vec![
                 ProducerConfig::Kubernetes {
                     namespace: Some("a".to_string()),

--- a/fml/src/config/themes.rs
+++ b/fml/src/config/themes.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeMap, HashSet};
+
 use config::{Config, File, FileFormat};
 
 use crate::{config::tui::ThemeConfig, error::FmlError};
@@ -15,8 +17,32 @@ const BUILTIN_THEMES: &[BuiltinTheme] = &[
         source: include_str!("themes/forest.toml"),
     },
     BuiltinTheme {
+        name: "kanagawa",
+        source: include_str!("themes/kanagawa.toml"),
+    },
+    BuiltinTheme {
         name: "kanagawa_dragon",
         source: include_str!("themes/kanagawa_dragon.toml"),
+    },
+    BuiltinTheme {
+        name: "gruvbox",
+        source: include_str!("themes/gruvbox.toml"),
+    },
+    BuiltinTheme {
+        name: "dracula",
+        source: include_str!("themes/dracula.toml"),
+    },
+    BuiltinTheme {
+        name: "catppuccin_mocha",
+        source: include_str!("themes/catppuccin_mocha.toml"),
+    },
+    BuiltinTheme {
+        name: "tokyo_night",
+        source: include_str!("themes/tokyo_night.toml"),
+    },
+    BuiltinTheme {
+        name: "nord",
+        source: include_str!("themes/nord.toml"),
     },
     BuiltinTheme {
         name: "mono",
@@ -31,30 +57,70 @@ const BUILTIN_THEMES: &[BuiltinTheme] = &[
 pub fn resolve_theme(
     theme_name: &str,
     default_theme: &ThemeConfig,
+    user_themes: &BTreeMap<String, ThemeConfig>,
 ) -> Result<ThemeConfig, FmlError> {
-    let normalized = theme_name.trim().to_ascii_lowercase();
+    let normalized = normalize_theme_name(theme_name);
 
     if normalized == DEFAULT_THEME_NAME {
         return Ok(default_theme.clone());
     }
 
-    let builtin = BUILTIN_THEMES
+    if let Some(builtin) = BUILTIN_THEMES
         .iter()
         .find(|builtin| builtin.name == normalized)
-        .ok_or_else(|| {
-            FmlError::Theme(format!(
-                "unknown theme `{theme_name}`; available themes: {}",
-                available_theme_names().join(", ")
-            ))
-        })?;
+    {
+        return parse_theme_source(builtin.name, builtin.source);
+    }
 
-    parse_theme_source(builtin.name, builtin.source)
+    if let Some((_, theme)) = user_themes
+        .iter()
+        .find(|(name, _)| normalize_theme_name(name) == normalized)
+    {
+        return Ok(theme.clone());
+    }
+
+    Err(FmlError::Theme(format!(
+        "unknown theme `{theme_name}`; available themes: {}",
+        available_theme_names(user_themes).join(", ")
+    )))
 }
 
-fn available_theme_names() -> Vec<&'static str> {
-    let mut names = vec![DEFAULT_THEME_NAME];
-    names.extend(BUILTIN_THEMES.iter().map(|builtin| builtin.name));
+/// Validate user-defined theme names against built-in and reserved theme names.
+pub fn validate_user_themes(user_themes: &BTreeMap<String, ThemeConfig>) -> Result<(), FmlError> {
+    let mut seen = HashSet::new();
+    for name in user_themes.keys() {
+        let normalized = normalize_theme_name(name);
+        if normalized == DEFAULT_THEME_NAME
+            || BUILTIN_THEMES
+                .iter()
+                .any(|builtin| builtin.name == normalized)
+        {
+            return Err(FmlError::Theme(format!(
+                "user-defined theme `{name}` collides with a built-in theme name"
+            )));
+        }
+        if !seen.insert(normalized) {
+            return Err(FmlError::Theme(format!(
+                "user-defined theme `{name}` collides with another user-defined theme name"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn available_theme_names(user_themes: &BTreeMap<String, ThemeConfig>) -> Vec<String> {
+    let mut names = vec![DEFAULT_THEME_NAME.to_string()];
+    names.extend(
+        BUILTIN_THEMES
+            .iter()
+            .map(|builtin| builtin.name.to_string()),
+    );
+    names.extend(user_themes.keys().cloned());
     names
+}
+
+fn normalize_theme_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
 }
 
 fn parse_theme_source(theme_name: &str, source: &str) -> Result<ThemeConfig, FmlError> {
@@ -76,7 +142,11 @@ fn parse_theme_source(theme_name: &str, source: &str) -> Result<ThemeConfig, Fml
 
 #[cfg(test)]
 mod tests {
-    use ratatui::style::Color;
+    use std::collections::BTreeMap;
+
+    use ratatui::style::{Color, Modifier};
+
+    use crate::config::tui::LogMatchStyle;
 
     use super::*;
 
@@ -87,14 +157,14 @@ mod tests {
             ..ThemeConfig::default()
         };
 
-        let resolved = resolve_theme(DEFAULT_THEME_NAME, &custom_theme).unwrap();
+        let resolved = resolve_theme(DEFAULT_THEME_NAME, &custom_theme, &BTreeMap::new()).unwrap();
 
         assert_eq!(resolved, custom_theme);
     }
 
     #[test]
     fn built_in_theme_loads_from_embedded_toml() {
-        let resolved = resolve_theme("ocean", &ThemeConfig::default()).unwrap();
+        let resolved = resolve_theme("ocean", &ThemeConfig::default(), &BTreeMap::new()).unwrap();
 
         assert_eq!(resolved.background, Some(Color::Rgb(0x11, 0x1C, 0x2D)));
         assert_eq!(resolved.secondary_accent_fg, Color::LightCyan);
@@ -104,14 +174,15 @@ mod tests {
 
     #[test]
     fn theme_lookup_is_case_insensitive() {
-        let resolved = resolve_theme("FoReSt", &ThemeConfig::default()).unwrap();
+        let resolved = resolve_theme("FoReSt", &ThemeConfig::default(), &BTreeMap::new()).unwrap();
 
         assert_eq!(resolved.secondary_accent_fg, Color::LightGreen);
     }
 
     #[test]
     fn kanagawa_dragon_theme_loads_expected_palette() {
-        let resolved = resolve_theme("kanagawa_dragon", &ThemeConfig::default()).unwrap();
+        let resolved =
+            resolve_theme("kanagawa_dragon", &ThemeConfig::default(), &BTreeMap::new()).unwrap();
 
         assert_eq!(resolved.background, Some(Color::Rgb(0x18, 0x16, 0x16)));
         assert_eq!(resolved.secondary_accent_fg, Color::Rgb(0x87, 0xA9, 0x87));
@@ -119,12 +190,143 @@ mod tests {
     }
 
     #[test]
-    fn unknown_theme_lists_available_builtins() {
-        let error = resolve_theme("missing", &ThemeConfig::default()).unwrap_err();
+    fn new_built_in_themes_load_expected_palettes() {
+        let cases = [
+            (
+                "kanagawa",
+                Color::Rgb(0x1F, 0x1F, 0x28),
+                Color::Rgb(0xE6, 0xC3, 0x84),
+            ),
+            (
+                "gruvbox",
+                Color::Rgb(0x28, 0x28, 0x28),
+                Color::Rgb(0xFA, 0xBD, 0x2F),
+            ),
+            (
+                "dracula",
+                Color::Rgb(0x28, 0x2A, 0x36),
+                Color::Rgb(0xBD, 0x93, 0xF9),
+            ),
+            (
+                "catppuccin_mocha",
+                Color::Rgb(0x1E, 0x1E, 0x2E),
+                Color::Rgb(0xCB, 0xA6, 0xF7),
+            ),
+            (
+                "tokyo_night",
+                Color::Rgb(0x1A, 0x1B, 0x26),
+                Color::Rgb(0x7A, 0xA2, 0xF7),
+            ),
+            (
+                "nord",
+                Color::Rgb(0x2E, 0x34, 0x40),
+                Color::Rgb(0x88, 0xC0, 0xD0),
+            ),
+        ];
+
+        for (name, background, accent) in cases {
+            let resolved = resolve_theme(name, &ThemeConfig::default(), &BTreeMap::new()).unwrap();
+
+            assert_eq!(resolved.background, Some(background));
+            assert_eq!(resolved.primary_accent_fg, accent);
+            assert_eq!(resolved.log_selected_modifier, Modifier::BOLD);
+            assert_eq!(resolved.log_match_style, LogMatchStyle::Color);
+        }
+    }
+
+    #[test]
+    fn built_in_themes_set_full_theme_config_surface() {
+        let required_top_level = [
+            "background",
+            "border_unfocused_fg",
+            "primary_accent_fg",
+            "secondary_accent_fg",
+            "source_selector_producer_fg",
+            "source_selector_group_fg",
+            "source_selector_source_fg",
+            "log_selected_bg",
+            "log_selected_modifier",
+            "log_match_fg",
+            "log_match_style",
+            "log_match_bold",
+            "status_dim",
+            "log_level",
+        ];
+        let required_log_level = [
+            "default_fg",
+            "trace_fg",
+            "debug_fg",
+            "info_fg",
+            "warn_fg",
+            "error_fg",
+            "fatal_fg",
+        ];
+
+        for builtin in BUILTIN_THEMES {
+            let value: toml::Value = builtin.source.parse().unwrap();
+            let table = value.as_table().unwrap();
+            for key in required_top_level {
+                assert!(table.contains_key(key), "{} missing {key}", builtin.name);
+            }
+            let log_level = table
+                .get("log_level")
+                .and_then(|value| value.as_table())
+                .unwrap();
+            for key in required_log_level {
+                assert!(
+                    log_level.contains_key(key),
+                    "{} missing log_level.{key}",
+                    builtin.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn user_defined_theme_resolves_by_name() {
+        let mut user_themes = BTreeMap::new();
+        user_themes.insert(
+            "solarized".to_string(),
+            ThemeConfig {
+                primary_accent_fg: Color::Rgb(0xB5, 0x89, 0x00),
+                ..ThemeConfig::default()
+            },
+        );
+
+        let resolved = resolve_theme("solarized", &ThemeConfig::default(), &user_themes).unwrap();
+
+        assert_eq!(resolved.primary_accent_fg, Color::Rgb(0xB5, 0x89, 0x00));
+    }
+
+    #[test]
+    fn unknown_theme_lists_available_builtins_and_user_themes() {
+        let mut user_themes = BTreeMap::new();
+        user_themes.insert("solarized".to_string(), ThemeConfig::default());
+        let error = resolve_theme("missing", &ThemeConfig::default(), &user_themes).unwrap_err();
 
         let message = error.to_string();
         assert!(message.contains("unknown theme `missing`"));
-        assert!(message.contains("default, forest, kanagawa_dragon, mono, ocean"));
+        assert!(message.contains("default, forest, kanagawa, kanagawa_dragon"));
+        assert!(message.contains("gruvbox"));
+        assert!(message.contains("dracula"));
+        assert!(message.contains("catppuccin_mocha"));
+        assert!(message.contains("tokyo_night"));
+        assert!(message.contains("nord"));
+        assert!(message.contains("solarized"));
+    }
+
+    #[test]
+    fn user_defined_theme_cannot_collide_with_builtin_name() {
+        let mut user_themes = BTreeMap::new();
+        user_themes.insert("Forest".to_string(), ThemeConfig::default());
+
+        let error = validate_user_themes(&user_themes).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("collides with a built-in theme name")
+        );
     }
 
     #[test]

--- a/fml/src/config/themes/catppuccin_mocha.toml
+++ b/fml/src/config/themes/catppuccin_mocha.toml
@@ -1,0 +1,22 @@
+background = "#1E1E2E"
+border_unfocused_fg = "#6C7086"
+primary_accent_fg = "#CBA6F7"
+secondary_accent_fg = "#89B4FA"
+source_selector_producer_fg = "#CBA6F7"
+source_selector_group_fg = "#94E2D5"
+source_selector_source_fg = "#CDD6F4"
+log_selected_bg = "#313244"
+log_selected_modifier = "BOLD"
+log_match_fg = "#F9E2AF"
+log_match_style = "color"
+log_match_bold = true
+status_dim = true
+
+[log_level]
+default_fg = "#CDD6F4"
+trace_fg = "#6C7086"
+debug_fg = "#89B4FA"
+info_fg = "#A6E3A1"
+warn_fg = "#F9E2AF"
+error_fg = "#F38BA8"
+fatal_fg = "#FAB387"

--- a/fml/src/config/themes/dracula.toml
+++ b/fml/src/config/themes/dracula.toml
@@ -1,0 +1,22 @@
+background = "#282A36"
+border_unfocused_fg = "#6272A4"
+primary_accent_fg = "#BD93F9"
+secondary_accent_fg = "#8BE9FD"
+source_selector_producer_fg = "#BD93F9"
+source_selector_group_fg = "#FFB86C"
+source_selector_source_fg = "#F8F8F2"
+log_selected_bg = "#44475A"
+log_selected_modifier = "BOLD"
+log_match_fg = "#F1FA8C"
+log_match_style = "color"
+log_match_bold = true
+status_dim = true
+
+[log_level]
+default_fg = "#F8F8F2"
+trace_fg = "#6272A4"
+debug_fg = "#8BE9FD"
+info_fg = "#50FA7B"
+warn_fg = "#F1FA8C"
+error_fg = "#FF5555"
+fatal_fg = "#FF79C6"

--- a/fml/src/config/themes/forest.toml
+++ b/fml/src/config/themes/forest.toml
@@ -1,12 +1,14 @@
 background = "#0F1A14"
-border_unfocused_fg = "DarkGray"
+border_unfocused_fg = "#3A4A40"
 primary_accent_fg = "LightGreen"
 secondary_accent_fg = "LightGreen"
 source_selector_producer_fg = "LightGreen"
 source_selector_group_fg = "Yellow"
 source_selector_source_fg = "Gray"
 log_selected_bg = "#1C2E22"
+log_selected_modifier = "BOLD"
 log_match_fg = "LightYellow"
+log_match_style = "color"
 log_match_bold = true
 status_dim = true
 

--- a/fml/src/config/themes/gruvbox.toml
+++ b/fml/src/config/themes/gruvbox.toml
@@ -1,0 +1,22 @@
+background = "#282828"
+border_unfocused_fg = "#665C54"
+primary_accent_fg = "#FABD2F"
+secondary_accent_fg = "#B8BB26"
+source_selector_producer_fg = "#FABD2F"
+source_selector_group_fg = "#83A598"
+source_selector_source_fg = "#EBDBB2"
+log_selected_bg = "#3C3836"
+log_selected_modifier = "BOLD"
+log_match_fg = "#FE8019"
+log_match_style = "color"
+log_match_bold = true
+status_dim = true
+
+[log_level]
+default_fg = "#EBDBB2"
+trace_fg = "#928374"
+debug_fg = "#83A598"
+info_fg = "#B8BB26"
+warn_fg = "#FABD2F"
+error_fg = "#FB4934"
+fatal_fg = "#CC241D"

--- a/fml/src/config/themes/kanagawa.toml
+++ b/fml/src/config/themes/kanagawa.toml
@@ -1,0 +1,22 @@
+background = "#1F1F28"
+border_unfocused_fg = "#54546D"
+primary_accent_fg = "#E6C384"
+secondary_accent_fg = "#7E9CD8"
+source_selector_producer_fg = "#E6C384"
+source_selector_group_fg = "#7E9CD8"
+source_selector_source_fg = "#DCD7BA"
+log_selected_bg = "#2D4F67"
+log_selected_modifier = "BOLD"
+log_match_fg = "#FF9E3B"
+log_match_style = "color"
+log_match_bold = true
+status_dim = true
+
+[log_level]
+default_fg = "#DCD7BA"
+trace_fg = "#727169"
+debug_fg = "#7E9CD8"
+info_fg = "#98BB6C"
+warn_fg = "#E6C384"
+error_fg = "#E82424"
+fatal_fg = "#FF5D62"

--- a/fml/src/config/themes/kanagawa_dragon.toml
+++ b/fml/src/config/themes/kanagawa_dragon.toml
@@ -1,12 +1,14 @@
 background = "#181616"
-border_unfocused_fg = "DarkGray"
+border_unfocused_fg = "#54546D"
 primary_accent_fg = "#C4B28A"
 secondary_accent_fg = "#87A987"
 source_selector_producer_fg = "#C4B28A"
 source_selector_group_fg = "#87A987"
 source_selector_source_fg = "#C5C9C5"
 log_selected_bg = "#2D4F67"
+log_selected_modifier = "BOLD"
 log_match_fg = "#8BA4B0"
+log_match_style = "color"
 log_match_bold = true
 status_dim = true
 

--- a/fml/src/config/themes/mono.toml
+++ b/fml/src/config/themes/mono.toml
@@ -6,7 +6,9 @@ source_selector_producer_fg = "White"
 source_selector_group_fg = "LightGray"
 source_selector_source_fg = "Gray"
 log_selected_bg = "DarkGray"
+log_selected_modifier = "BOLD"
 log_match_fg = "White"
+log_match_style = "color"
 log_match_bold = true
 status_dim = true
 

--- a/fml/src/config/themes/nord.toml
+++ b/fml/src/config/themes/nord.toml
@@ -1,0 +1,22 @@
+background = "#2E3440"
+border_unfocused_fg = "#4C566A"
+primary_accent_fg = "#88C0D0"
+secondary_accent_fg = "#8FBCBB"
+source_selector_producer_fg = "#88C0D0"
+source_selector_group_fg = "#EBCB8B"
+source_selector_source_fg = "#D8DEE9"
+log_selected_bg = "#3B4252"
+log_selected_modifier = "BOLD"
+log_match_fg = "#EBCB8B"
+log_match_style = "color"
+log_match_bold = true
+status_dim = true
+
+[log_level]
+default_fg = "#D8DEE9"
+trace_fg = "#4C566A"
+debug_fg = "#81A1C1"
+info_fg = "#A3BE8C"
+warn_fg = "#EBCB8B"
+error_fg = "#BF616A"
+fatal_fg = "#D08770"

--- a/fml/src/config/themes/ocean.toml
+++ b/fml/src/config/themes/ocean.toml
@@ -1,12 +1,14 @@
 background = "#111C2D"
-border_unfocused_fg = "DarkGray"
+border_unfocused_fg = "#4A5C70"
 primary_accent_fg = "LightCyan"
 secondary_accent_fg = "LightCyan"
 source_selector_producer_fg = "LightCyan"
 source_selector_group_fg = "LightBlue"
 source_selector_source_fg = "Gray"
 log_selected_bg = "#16304A"
+log_selected_modifier = "BOLD"
 log_match_fg = "Cyan"
+log_match_style = "color"
 log_match_bold = true
 status_dim = true
 

--- a/fml/src/config/themes/tokyo_night.toml
+++ b/fml/src/config/themes/tokyo_night.toml
@@ -1,0 +1,22 @@
+background = "#1A1B26"
+border_unfocused_fg = "#565F89"
+primary_accent_fg = "#7AA2F7"
+secondary_accent_fg = "#BB9AF7"
+source_selector_producer_fg = "#7AA2F7"
+source_selector_group_fg = "#73DACA"
+source_selector_source_fg = "#C0CAF5"
+log_selected_bg = "#292E42"
+log_selected_modifier = "BOLD"
+log_match_fg = "#E0AF68"
+log_match_style = "color"
+log_match_bold = true
+status_dim = true
+
+[log_level]
+default_fg = "#C0CAF5"
+trace_fg = "#565F89"
+debug_fg = "#7DCFFF"
+info_fg = "#9ECE6A"
+warn_fg = "#E0AF68"
+error_fg = "#F7768E"
+fatal_fg = "#FF9E64"

--- a/fml/src/config/tui.rs
+++ b/fml/src/config/tui.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use ratatui::style::{Color, Modifier, Style};
 use serde::{Deserialize, Serialize};
 
@@ -24,8 +26,8 @@ pub struct TuiConfig {
 
     /// Built-in theme to apply to the TUI.
     ///
-    /// `default` uses the colors from `[tui.default_theme]`. Built-in themes
-    /// currently available are `forest`, `kanagawa_dragon`, `mono`, and `ocean`.
+    /// `default` uses the colors from `[tui.default_theme]`. Built-in and
+    /// user-defined themes can also be selected by name.
     #[serde(default = "default_theme_name")]
     pub theme: String,
 
@@ -59,7 +61,15 @@ impl Default for TuiConfig {
 impl TuiConfig {
     /// Resolve the configured theme selector into the concrete widget palette.
     pub fn resolved_theme(&self) -> Result<ThemeConfig, FmlError> {
-        super::themes::resolve_theme(&self.theme, &self.default_theme)
+        super::themes::resolve_theme(&self.theme, &self.default_theme, &BTreeMap::new())
+    }
+
+    /// Resolve the configured theme selector, including top-level user themes.
+    pub fn resolved_theme_with(
+        &self,
+        user_themes: &BTreeMap<String, ThemeConfig>,
+    ) -> Result<ThemeConfig, FmlError> {
+        super::themes::resolve_theme(&self.theme, &self.default_theme, user_themes)
     }
 }
 

--- a/fml/src/main.rs
+++ b/fml/src/main.rs
@@ -80,6 +80,9 @@ impl Cli {
             config.tui.frame_rate = frame_rate;
         }
 
+        let active_profile = self.profile.clone().or_else(|| config.profile.clone());
+        config.apply_profile_overrides(active_profile.as_deref())?;
+
         if let Some(theme) = &self.theme {
             config.tui.theme = theme.clone();
         }

--- a/fml/src/state.rs
+++ b/fml/src/state.rs
@@ -35,7 +35,7 @@ impl AppState {
     pub fn new(config: Config) -> Result<Self, FmlError> {
         let store = RingBufferStore::new(config.store.clone());
         let event_bus = EventBus::new();
-        let mut tui = TuiState::new(&config.tui, &config.search)?;
+        let mut tui = TuiState::new_with_themes(&config.tui, &config.search, &config.themes)?;
         tui.log_pane.set_store_stats(store.stats());
 
         Ok(AppState {

--- a/fml/src/state/tui_state.rs
+++ b/fml/src/state/tui_state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use ratatui::layout::Rect;
 use ratatui_textarea::TextArea;
@@ -89,7 +89,16 @@ pub struct TuiState {
 
 impl TuiState {
     pub fn new(tui_config: &TuiConfig, search_config: &SearchConfig) -> Result<Self, FmlError> {
-        let selected_theme = tui_config.resolved_theme()?;
+        Self::new_with_themes(tui_config, search_config, &BTreeMap::new())
+    }
+
+    /// Build TUI state with top-level user-defined themes available for theme resolution.
+    pub fn new_with_themes(
+        tui_config: &TuiConfig,
+        search_config: &SearchConfig,
+        user_themes: &BTreeMap<String, ThemeConfig>,
+    ) -> Result<Self, FmlError> {
+        let selected_theme = tui_config.resolved_theme_with(user_themes)?;
         Ok(TuiState {
             focused: Slot::Main,
             areas: HashMap::new(),


### PR DESCRIPTION
## Summary

- Add built-in Kanagawa, Gruvbox, Dracula, Catppuccin Mocha, Tokyo Night, and Nord themes.
- Refine all existing built-in theme TOML files so every `ThemeConfig` field and nested log-level color is explicitly covered.
- Add top-level `[themes.<name>]` user-defined themes, selectable with `tui.theme`, with collision validation and richer unknown-theme errors.

## Acceptance Criteria

- [x] Add popular shipped themes: Gruvbox, Dracula, Catppuccin, Tokyo Night, Nord.
- [x] Add plain Kanagawa.
- [x] Each shipped theme covers the full `ThemeConfig` surface.
- [x] Existing built-ins reviewed/refined for full theme surface coverage.
- [x] Shipped themes have load + spot-check tests.
- [x] Config supports `[themes.<name>]` and `theme = "<name>"`.
- [x] Built-in/user theme errors list all available names.
- [x] User theme collisions with built-ins return a clear config error.

## Verification

- `cargo test -p fml config::`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`
- pre-commit hooks: cargo build, test, fmt, clippy

Closes #12
