### PR TITLE
feat(tui): add select mode toggle and OSC 52 entry yank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,7 @@ name = "fml"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "bollard",
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tracing-subscriber = { version = "0.3.22", features = [
 tui-popup = "0.7.2"
 tui-scrollview = "0.6.2"
 
+base64 = "0.22"
 insta = "1"
 testcontainers = "0.27.3"
 

--- a/docs/plans/yank-bigplan.md
+++ b/docs/plans/yank-bigplan.md
@@ -1,0 +1,219 @@
+# BIGPLAN: Text Selection & Yank (#15)
+
+## Plan Overview
+
+Make it easy to get text out of the fml TUI for sharing or further investigation. Two complementary mechanisms: (a) a toggleable **select mode** that releases crossterm's mouse capture so the host terminal's native click-drag selection (and its built-in copy path) work as users already expect; (b) a **yank shortcut** active only when the log pane is focused that serializes the currently selected `LogEntry` as JSON and writes it to the system clipboard via an **OSC52** escape sequence. The OSC52 path avoids native clipboard libraries (no X11/Wayland deps, works over SSH). "Done" means: pressing the select-mode toggle lets users drag-highlight any visible text and copy via the terminal's own shortcut; pressing `y` with the log pane focused emits an OSC52 yank that supported terminals deliver to the system clipboard; neither path degrades existing rendering, event flow, or perceived input latency. Note that delivery is "best effort by terminal" — see Risks; the status-bar message reflects what fml _did_, not what the clipboard _received_.
+
+## Risks
+
+- **Mouse capture toggle leaks state on panic/exit** — `EnableMouseCapture` is set at `app.rs:212` and `DisableMouseCapture` is wired in the panic hook (`tui.rs:41`) and shutdown (`tui.rs:53`). The plan keeps capture _always on at startup_ and toggles to off in select mode, so the existing unconditional teardown remains correct. Mitigation: do not make startup `EnableMouseCapture` conditional (revised from the earlier draft); only the runtime toggle is new. Issuing `DisableMouseCapture` is documented-safe regardless of current state.
+- **OSC52 success is unobservable from inside the process** — there is no in-band reply to an OSC52 write, no `$TERM`-based detection that is reliable, and many common environments silently drop the sequence: macOS Terminal.app (no support at all), GNOME Terminal / VTE before 3.50, Windows Console Host (only ConPTY-wrapped Windows Terminal works, and only on recent builds), tmux without `set -g set-clipboard on`, Zellij when the host terminal does not support OSC52 or its clipboard path is otherwise misconfigured, plain SSH into an old xterm. Mitigation: the status-bar message says **"sent yank (N bytes) — check clipboard"** rather than confirming a copy; the README and help popup list the known-good terminals and call out the unsupported or config-dependent ones by name; no fallback library is added.
+- **OSC52 payload caps vary by terminal** — published caps: xterm 8KB (smallest common cap), gnome-terminal/vte 8KB historically, alacritty ~100KB practical, kitty/wezterm/iTerm2 effectively unbounded, tmux 1MB with `set-clipboard on`. Zellij's own copy path uses OSC52 by default and can be configured with `copy_command`, but fml's direct OSC52 yank still ultimately depends on the multiplexer and host terminal forwarding/accepting the sequence. The plan picks the **conservative xterm cap of 8KB** as the warning threshold so users in the worst supported environment get a meaningful signal. Mitigation: warn when the **base64-encoded** payload exceeds 8KB; the message names the cap so users know which environments are at risk. No chunked protocol (not standardized).
+- **Multiplexers are the most likely silent-failure environment** — fml's audience overlaps heavily with tmux and Zellij users. Tmux drops OSC52 unless `set -g set-clipboard on` is configured. Zellij uses OSC52 for its own copy path by default and documents `copy_command` as the fallback when the host terminal does not support OSC52, but nested application OSC52 behavior still needs real verification. Documentation alone is a weak mitigation. Mitigation: detect `$TMUX` and `$ZELLIJ` and on the _first_ yank in that session show a one-time status-bar hint using a shared `multiplexer_clipboard_hint_shown` flag. No bare-tmux passthrough wrapper and no Zellij-specific escape wrapper in this plan; only modern/configured multiplexer behavior is first-class.
+- **Mouse-capture release loses in-app mouse events** — verified by grep at plan time: no widget consumes `TuiEvent::Mouse` (the variant is dispatched in `tui.rs:83` and ignored everywhere else). The toggle therefore has zero functional regression today. **But** for users who rely on terminal scrollback wheel scrolling, the _current_ default of capture-on already blocks that; the new toggle is the _first_ way to get scrollback back. Mitigation: document this user-visible upside in the README; pin the grep result as a verification task in Deliverable 1 so the assumption is checked at implementation time, not just plan time.
+- **Synchronous stdout write inside the event loop can block** — OSC52 is a stdout write, and stdout can in principle block (slow pipe, Ctrl+S pause, tmux backpressure). The same pattern is already used by ratatui's `terminal.draw` and the existing `EnableMouseCapture` call, so this is consistent with current behavior. Mitigation: accept the risk for typical payload sizes (≤ a few KB for a log entry); the 8KB warning naturally caps the worst case; do not move the write off the event-loop thread.
+- **Selection state is already defined** — `state.tui.selected_entry: Option<SelectedEntry>` exists at `fml/src/state/tui_state.rs:81`. "No selection" means `None`. The yank task does _not_ introduce a new selection model.
+
+## Plan Details
+
+### Critical Files
+
+- `fml/src/app.rs` — leave `EnableMouseCapture` at `app.rs:212` **unconditional** at startup. The toggle operates at runtime only; this preserves the existing teardown invariant.
+- `fml/src/tui.rs` — panic hook (`tui.rs:41`) and `kill()` (`tui.rs:53`) unconditionally issue `DisableMouseCapture` (no change). Also home of the crossterm event reader; mouse events flow into `TuiEvent::Mouse` and remain unhandled.
+- `fml/src/event.rs` — no new event variants required. Toggle and yank are both produced as `CustomizedKeyAction` values and handled inline in `handle_tui_event`.
+- `fml/src/state/tui_state.rs` — `TuiState` gains: `select_mode: bool` (default `false`); `status_message: Option<StatusMessage>` (transient slot used by Deliverable 0); `multiplexer_clipboard_hint_shown: bool` (one-shot flag for tmux/Zellij clipboard hints).
+- `fml/src/config/tui.rs` — extend the existing `[tui.keybindings]` surface with `toggle_select_mode` and `yank_selected_entry` defaulting to `["f2"]` and `["y"]`, so help/status labels stay aligned with the config contract already documented for keybindings.
+- `fml/src/tui/keybinds.rs` — add `CustomizedKeyAction::ToggleSelectMode` (hint section `HelpSection::Global`, default label `F2`) and `CustomizedKeyAction::YankSelectedEntry` (hint section `HelpSection::LogPane`, default label `y`), wired through the same runtime binding resolution used by existing configurable actions.
+- `fml/src/tui.rs` (`handle_tui_event`) — branch on `ToggleSelectMode` to flip `state.tui.select_mode` and execute `EnableMouseCapture`/`DisableMouseCapture`; branch on `YankSelectedEntry` only when `state.tui.focused == Slot::LogPane` and no popup is active.
+- `fml/src/log.rs` — `LogEntry` already derives `Serialize` (line 58–73). `serde_json::to_string(&*entry)` is all that's needed.
+- New: `fml/src/clipboard.rs` — `pub fn yank_osc52<W: Write>(out: &mut W, payload: &str) -> Result<usize, FmlError>`. Encodes via `base64` (pure-Rust crate, no system deps), writes `\x1b]52;c;<base64>\x1b\\`, returns the encoded byte length. The `impl Write` parameter makes it unit-testable with a `Cursor<Vec<u8>>`.
+- `fml/src/tui/widgets/status_bar.rs` — render the transient `status_message` (Deliverable 0) and a small `[SELECT]` indicator when `select_mode == true`.
+
+### Gotchas
+
+- **Mouse capture is currently a no-op** — `TuiEvent::Mouse` is dispatched but unhandled (verified by grep: zero `MouseEventKind` matches outside the dispatch site). The toggle therefore has zero functional regression on current features.
+- **Startup capture stays on** — do not make startup capture conditional; only the runtime toggle is new. This keeps the existing panic/exit invariant intact (always disable on teardown, regardless of starting state).
+- **Selected entry source** — yank reads `state.tui.selected_entry: Option<SelectedEntry>` (defined at `fml/src/state/tui_state.rs:81`); `None` is the no-op case.
+- **Keybind choice** — `F2` is the chosen toggle key. Ctrl+\ was considered but is the POSIX SIGQUIT chord; while crossterm raw mode masks it, F2 is unambiguous and matches the function-key convention used elsewhere (e.g., midnight commander, htop).
+- **`stdout().execute(...)` from inside the event loop is synchronous** — same pattern as the existing capture call at `app.rs:212`. Safe.
+- **Render contention with OSC52 writes** — `render()` runs on the same thread as input handling and also writes to stdout. Writing OSC52 between frames is fine; ratatui's draw call flushes before returning.
+- **`y` in query box** — query box uses `tui-textarea` and captures alphanumerics when focused. Because yank is gated on `focused == Slot::LogPane`, typing `y` in the query box continues to insert the character.
+- **`Y` (shift-y) stays unbound** — out of scope for this plan; log pane already binds `G` for jump-to-tail and we want symmetry with future "yank N" behaviors before claiming `Y`.
+- **Help popup auto-updates** — built from action hints and runtime keybinding labels. New entries appear automatically once added, and their displayed labels must follow `[tui.keybindings]` overrides.
+- **`base64` is pure-Rust** — the `base64` crate (`0.22`) has no system requirements. Adding it does not undo the "no native deps" rationale for choosing OSC52 over a clipboard library.
+- **Multiplexer detection** — `std::env::var("TMUX").is_ok()` and `std::env::var("ZELLIJ").is_ok()` are sufficient for first-yank hints; both variables are set for nested processes by their respective multiplexers. If both are present, prefer the more specific status message `multiplexer: clipboard may need tmux/Zellij setup`.
+- **OSC52 success cannot be confirmed** — fml only knows it _wrote_ the sequence. All user-facing messages should be honest about that ("sent yank — check clipboard").
+
+### Pseudo-code / Sketches
+
+```text
+// fml/src/clipboard.rs
+pub fn yank_osc52<W: Write>(out: &mut W, payload: &str) -> Result<usize, FmlError> {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(payload);
+    let len = encoded.len();
+    write!(out, "\x1b]52;c;{}\x1b\\", encoded)?;
+    out.flush()?;
+    Ok(len)
+}
+
+// fml/src/tui.rs, inside handle_tui_event Input branch
+const OSC52_WARN_BYTES: usize = 8 * 1024; // xterm/vte conservative cap
+
+if custom_key == CustomizedKeyAction::ToggleSelectMode {
+    state.tui.select_mode = !state.tui.select_mode;
+    let _ = if state.tui.select_mode {
+        stdout().execute(DisableMouseCapture)
+    } else {
+        stdout().execute(EnableMouseCapture)
+    };
+    return state;
+}
+if custom_key == CustomizedKeyAction::YankSelectedEntry
+    && state.tui.focused == Slot::LogPane
+    && state.tui.active_popup().is_none()
+{
+    let Some(selected) = state.tui.selected_entry.as_ref() else {
+        return state; // silent no-op; nothing to yank
+    };
+    let json = serde_json::to_string(&*selected.entry).unwrap_or_default();
+    let mut out = stdout().lock();
+    let msg = match clipboard::yank_osc52(&mut out, &json) {
+        Ok(n) if n > OSC52_WARN_BYTES =>
+            format!("sent yank ({n} bytes) — exceeds 8KB; xterm/vte may drop it"),
+        Ok(n) => format!("sent yank ({n} bytes) — check clipboard"),
+        Err(e) => format!("yank failed: {e}"),
+    };
+    let now = Instant::now();
+    state.tui.set_status_message(msg, now);
+    if multiplexer_hint().is_some() && !state.tui.multiplexer_clipboard_hint_shown {
+        state.tui.multiplexer_clipboard_hint_shown = true;
+        state.tui.queue_status_message(multiplexer_hint().unwrap(), now);
+    }
+    return state;
+}
+```
+
+## Deliverables
+
+### Deliverable 0. Status-bar transient message infrastructure
+
+Add a transient-message slot to `TuiState` and surface it in the status bar widget. This is shared infrastructure used by Deliverables 1 and 3 (`[SELECT]` indicator, "sent yank" message, multiplexer hint). Pinning it as its own deliverable removes the implicit dependency and the design churn of Deliverable 1 inventing a model that Deliverable 3 then retrofits.
+
+Acceptance:
+
+- `TuiState::set_status_message(msg, now)` records the message with the caller-provided timestamp.
+- `TuiState::status_message(now)` returns `Some(&str)` only while the message is within a fixed TTL (proposed: 3 seconds); otherwise `None`. TTL is checked at render time, not via a background timer (no extra task). Passing `now` makes the production path and tests use the same API without sleeps or test-only helpers.
+- A render-time suppression flag (`TuiConfig::suppress_status_messages`, default `false`) lets snapshot tests render with messages hidden so existing snapshots stay stable.
+- The status bar renders the current transient message in a reserved region; absent message renders the existing content unchanged.
+
+- [ ] Add `status_message: Option<(String, Instant)>` and `status_message_ttl: Duration` to `TuiState`.
+- [ ] Add `set_status_message(msg, now)` / `status_message(now)` accessors using the TTL.
+- [ ] Add `suppress_status_messages: bool` to `TuiConfig` and route through to `status_bar` render.
+- [ ] Update `status_bar.rs` to render the message (when present and not suppressed) in a known region.
+- [ ] Unit test: `set_status_message(msg, now)` then call `status_message(now + ttl + 1ms)` → returns `None`.
+- [ ] Snapshot test: existing status-bar snapshots run with `suppress_status_messages = true` and remain byte-identical.
+
+### Deliverable 1. Toggleable mouse capture (select mode)
+
+Introduce a runtime-toggleable select mode bound to `F2`. On toggle-on, fml issues `DisableMouseCapture`, lets the terminal handle drag-selection and wheel scrollback, and shows a `[SELECT]` indicator in the status bar. On toggle-off, fml re-issues `EnableMouseCapture`. Startup capture remains unconditional so the existing teardown invariant holds.
+
+Acceptance:
+
+- `F2` flips capture state synchronously.
+- `[SELECT]` appears in the status bar when in select mode and is gone when not.
+- Quit (`Ctrl+C`/`q`), panic, and normal exit always leave the terminal with capture _off_, regardless of mode at exit.
+- Verified at implementation time: no widget consumes `TuiEvent::Mouse` (capture-off has no in-app regressions).
+
+- [ ] Add `select_mode: bool` to `TuiState` (default `false`).
+- [ ] Add `toggle_select_mode` to `TuiConfig.keybindings` with default `["f2"]`.
+- [ ] Add `CustomizedKeyAction::ToggleSelectMode` + action hint (`HelpSection::Global`, default label `F2`) sourced from runtime keybindings.
+- [ ] Wire toggle in `handle_tui_event`: flip the bool, execute `EnableMouseCapture`/`DisableMouseCapture`.
+- [ ] Render `[SELECT]` indicator in `status_bar.rs` when `select_mode == true`.
+- [ ] Re-grep `TuiEvent::Mouse` consumers at implementation time and pin the result in a comment near the toggle (sentinel against silent regressions if a future widget starts consuming mouse events).
+- [ ] Test: panic path while `select_mode == true` (`disable_raw_mode` + `DisableMouseCapture` both invoked); confirm `DisableMouseCapture` is a safe no-op when capture is already off.
+- [ ] Unit test: toggle action flips `state.tui.select_mode`.
+- [ ] Run snapshot suite; confirm zero diffs in the default state (select_mode off, no status message).
+
+### Deliverable 2. Clipboard module (OSC52 writer)
+
+A small, self-contained module that base64-encodes a string and writes the OSC52 sequence to an `impl Write`. Returns the encoded byte length so callers can warn on oversize payloads.
+
+Acceptance:
+
+- `yank_osc52(&mut buf, "hello")` writes exactly `\x1b]52;c;aGVsbG8=\x1b\\` to `buf`, returns `Ok(8)`.
+- `yank_osc52(&mut buf, "")` writes `\x1b]52;c;\x1b\\`, returns `Ok(0)`.
+- A write error from the underlying `Write` is mapped to `FmlError`.
+- No globals: the function takes the writer; callers (production) pass `stdout().lock()`; tests pass a `Cursor<Vec<u8>>`.
+
+- [ ] Add `base64 = "0.22"` to `fml/Cargo.toml`.
+- [ ] Create `fml/src/clipboard.rs` with `yank_osc52<W: Write>(...)`.
+- [ ] Register module in `fml/src/lib.rs`.
+- [ ] Unit test: exact byte sequence for `"hello"` via `Cursor<Vec<u8>>`.
+- [ ] Unit test: empty string.
+- [ ] Unit test: writer error path returns `FmlError`.
+
+### Deliverable 3. Yank selected entry shortcut
+
+Bind lowercase `y` to serialize `state.tui.selected_entry.entry` as JSON and emit it via `clipboard::yank_osc52`. Gated on log pane focus and no active popup. Surface the result through the Deliverable 0 status-bar slot. On first yank inside a tmux or Zellij session, queue a one-time multiplexer-specific hint.
+
+Acceptance:
+
+- With log pane focused and `selected_entry == Some(_)`, pressing `y` writes the entry JSON via OSC52 and shows **"sent yank (N bytes) — check clipboard"** (or the >8KB warning variant).
+- With log pane focused and `selected_entry == None`, `y` is a silent no-op (no message, no clipboard write).
+- With query box focused, `y` continues to insert the character.
+- With any popup open, `y` is swallowed by popup handlers (no regression).
+- Under `$TMUX`, the first yank also shows a one-time hint message about `set -g set-clipboard on`. Subsequent yanks in the same session do not repeat the hint.
+- Under `$ZELLIJ`, the first yank also shows a one-time hint message that Zellij clipboard delivery depends on OSC52-capable terminals or `copy_command` for Zellij's own copy path. Subsequent yanks in the same session do not repeat the hint.
+- The status-bar message wording reflects "sent," not "copied" — we cannot confirm clipboard receipt.
+
+- [ ] Add `yank_selected_entry` to `TuiConfig.keybindings` with default `["y"]`.
+- [ ] Add `CustomizedKeyAction::YankSelectedEntry` + action hint (`HelpSection::LogPane`, default label `y`) sourced from runtime keybindings.
+- [ ] Add focus + popup gating in `handle_tui_event` before the existing widget-dispatch loop.
+- [ ] Serialize entry with `serde_json::to_string(&*selected.entry)`.
+- [ ] Call `clipboard::yank_osc52` with `stdout().lock()`; route result string into `set_status_message`.
+- [ ] Implement the 8KB warning branch in the result-matching code; message names the cap.
+- [ ] Implement the `$TMUX` / `$ZELLIJ` one-time hint via `multiplexer_clipboard_hint_shown` flag on `TuiState`.
+- [ ] Unit test: yank with `selected_entry == None` is a silent no-op (no status message, no write).
+- [ ] Unit test: yank with query-box focus does not invoke the yank branch (gated out).
+- [ ] Unit test: yank with `selected_entry == Some(_)` produces expected JSON via a test seam (factor the write target so the test can pass a `Vec<u8>`).
+- [ ] Unit test: 8KB threshold — payload at exactly 8192 base64 bytes yields the normal message; 8193 yields the warning.
+- [ ] Unit test: with env var simulating `TMUX`, second yank in the same `TuiState` does not re-queue the hint.
+- [ ] Unit test: with env var simulating `ZELLIJ`, second yank in the same `TuiState` does not re-queue the hint.
+
+### Deliverable 4. Documentation & manual verification matrix
+
+Update the README so users know how to use both features and which terminals are supported. The help popup updates automatically from the action hints and runtime keybinding labels; this deliverable is README + a recorded manual verification matrix.
+
+Acceptance:
+
+- README has a new **"Selecting & copying text"** section explaining:
+  - `F2` toggles select mode for drag-highlight and terminal wheel scrollback.
+  - `y` (log pane focused) sends the selected entry as JSON via OSC52.
+  - **Tmux users need `set -g set-clipboard on`** (explicit acceptance criterion).
+  - **Zellij users should verify their host terminal supports OSC52; for Zellij's own copy path, `copy_command` is the documented fallback when OSC52 is unsupported** (explicit acceptance criterion).
+  - Known-working terminals: alacritty, wezterm, kitty, iTerm2, recent xterm, Windows Terminal (with ConPTY).
+  - Known-broken terminals: macOS Terminal.app, GNOME Terminal / VTE before 3.50, Windows Console Host, tmux without the setting above.
+- A manual verification matrix is recorded in the PR description (not in-repo) covering the cells below.
+
+Manual verification matrix (one PR pass; record outcome per cell):
+
+| Terminal                                      | Select-mode drag-copy | `y` yank (paste to external app) | Multiplexer note shown when applicable |
+| --------------------------------------------- | --------------------- | -------------------------------- | -------------------------------------- |
+| alacritty                                     | ✓                     | ✓                                | n/a                                    |
+| wezterm                                       | ✓                     | ✓                                | n/a                                    |
+| kitty                                         | ✓                     | ✓                                | n/a                                    |
+| inside tmux on alacritty (no `set-clipboard`) | ✓                     | ✗ silently dropped + hint shown  | ✓                                      |
+| inside tmux on alacritty (`set-clipboard on`) | ✓                     | ✓                                | ✓ on first only                        |
+| inside Zellij on alacritty                    | ✓                     | verify                           | ✓ on first only                        |
+| inside Zellij on wezterm                      | ✓                     | verify                           | ✓ on first only                        |
+| Terminal.app                                  | ✓                     | ✗ (documented as unsupported)    | n/a                                    |
+
+- [ ] Add README section per acceptance.
+- [ ] Verify the help popup renders both actions in their respective sections.
+- [ ] Run the manual matrix and paste outcomes into the PR.
+
+## Issues
+
+- **2026-05-17 — agent:codex** — Review follow-up merged: treat Zellij as a first-class multiplexer customer alongside tmux. The plan now uses `multiplexer_clipboard_hint_shown`, requires `$TMUX` and `$ZELLIJ` first-yank hints, adds Zellij README acceptance and verification matrix rows, keeps keybinding additions aligned with `[tui.keybindings]`, and makes transient status-message TTL tests deterministic by passing `Instant` into the production accessors. This also resolves the earlier deferred configurable yank-keybind follow-up for this feature slice.
+- **2026-05-16 — agent:claude (adversarial review)** — Plan reviewed by 2 adversarial sub-agents (Risks & Assumptions, Completeness & Scope). 20 findings; 19 merged. Most significant changes: (1) added Deliverable 0 for the status-bar transient-message infrastructure that D1 and D3 both depend on; (2) lowered the OSC52 warning threshold from 100KB to a conservative 8KB matching xterm/VTE; (3) added explicit `$TMUX` detection with a one-time first-yank hint instead of doc-only mitigation; (4) status-bar wording revised from "yanked" to "sent yank — check clipboard" to be honest about unobservability; (5) keybind decision committed to `F2`; (6) expanded Deliverable 4 into a documented manual verification matrix across supported and unsupported terminals; (7) pinned existing-snapshot stability behind a `TuiConfig::suppress_status_messages` flag. One reviewer finding deferred: adding a legacy `\ePtmux;...\e\\` passthrough wrapper — out of scope; only modern tmux with `set-clipboard on` is supported.
+- **2026-05-16 — agent:claude** — Plan drafted from issue #15 with pre-draft questions resolved by the user: mouse capture is toggled (not removed), yank covers selected entry as raw/JSON only, clipboard backend is OSC52, keybinding is vim-style `y` gated on log-pane focus. Open follow-ups deferred to future work, not this plan: (1) yanking a specific field value via a picker; (2) yanking the info-pane or preview-pane contents; (3) `Y` for whole-buffer or multi-entry yank; (4) configurable yank keybind via a `[keybinds]` config table; (5) legacy tmux passthrough wrapper.

--- a/fml/Cargo.toml
+++ b/fml/Cargo.toml
@@ -22,6 +22,7 @@ futures-util.workspace = true
 kube.workspace = true
 k8s-openapi.workspace = true
 anyhow.workspace = true
+base64.workspace = true
 color-eyre.workspace = true
 lazy_static.workspace = true
 tracing.workspace = true

--- a/fml/src/clipboard.rs
+++ b/fml/src/clipboard.rs
@@ -1,0 +1,68 @@
+use std::io::Write;
+
+use base64::Engine as _;
+
+use crate::error::FmlError;
+
+/// Maximum base64-encoded payload size before warning the user. xterm and
+/// older VTE cap OSC52 payloads at ~8 KB; exceeding this silently drops the
+/// yank in those terminals.
+pub const OSC52_WARN_BYTES: usize = 8 * 1024;
+
+/// Write an OSC 52 clipboard sequence to `out` and return the base64-encoded
+/// byte length of the payload.
+///
+/// OSC 52 is a best-effort sequence: there is no in-band reply confirming that
+/// the terminal actually wrote the clipboard. Delivery depends on terminal
+/// support and multiplexer configuration (see README for details).
+///
+/// The 8 KB threshold mentioned in the plan is the responsibility of callers —
+/// this function encodes and writes unconditionally.
+pub fn yank_osc52<W: Write>(out: &mut W, payload: &str) -> Result<usize, FmlError> {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(payload);
+    let len = encoded.len();
+    write!(out, "\x1b]52;c;{encoded}\x1b\\")?;
+    out.flush()?;
+    Ok(len)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn encodes_hello_as_exact_osc52_sequence() {
+        let mut buf = Cursor::new(Vec::new());
+        let n = yank_osc52(&mut buf, "hello").unwrap();
+        let result = String::from_utf8(buf.into_inner()).unwrap();
+        assert_eq!(result, "\x1b]52;c;aGVsbG8=\x1b\\");
+        assert_eq!(n, 8);
+    }
+
+    #[test]
+    fn empty_string_writes_osc52_with_empty_payload() {
+        let mut buf = Cursor::new(Vec::new());
+        let n = yank_osc52(&mut buf, "").unwrap();
+        let result = String::from_utf8(buf.into_inner()).unwrap();
+        assert_eq!(result, "\x1b]52;c;\x1b\\");
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn writer_error_returns_fml_error() {
+        struct FailWriter;
+        impl Write for FailWriter {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let result = yank_osc52(&mut FailWriter, "hello");
+        assert!(matches!(result, Err(FmlError::Io(_))));
+    }
+}

--- a/fml/src/config/tui.rs
+++ b/fml/src/config/tui.rs
@@ -44,6 +44,13 @@ pub struct TuiConfig {
     /// or disabled.
     #[serde(default)]
     pub keybindings: KeybindingsConfig,
+
+    /// When `true`, the status bar never renders transient messages.
+    ///
+    /// Intended for snapshot tests: set this flag so new status-message
+    /// infrastructure does not invalidate existing snapshots.
+    #[serde(default)]
+    pub suppress_status_messages: bool,
 }
 
 impl Default for TuiConfig {
@@ -54,6 +61,7 @@ impl Default for TuiConfig {
             theme: default_theme_name(),
             default_theme: ThemeConfig::default(),
             keybindings: KeybindingsConfig::default(),
+            suppress_status_messages: false,
         }
     }
 }
@@ -398,6 +406,19 @@ pub struct KeybindingsConfig {
     /// Only fires when the log pane has focus.
     #[serde(default = "default_show_info")]
     pub show_info: Vec<String>,
+
+    /// Toggle select mode (releases mouse capture so the terminal handles
+    /// drag-selection and wheel scrollback).
+    ///
+    /// Active globally. `F2` is the default and is distinct from POSIX SIGQUIT (`ctrl+\`).
+    #[serde(default = "default_toggle_select_mode")]
+    pub toggle_select_mode: Vec<String>,
+
+    /// Yank the currently selected log entry as JSON via OSC 52.
+    ///
+    /// Only fires when the log pane has focus and no popup is active.
+    #[serde(default = "default_yank_selected_entry")]
+    pub yank_selected_entry: Vec<String>,
 }
 
 impl Default for KeybindingsConfig {
@@ -405,6 +426,8 @@ impl Default for KeybindingsConfig {
         Self {
             toggle_help: default_toggle_help(),
             show_info: default_show_info(),
+            toggle_select_mode: default_toggle_select_mode(),
+            yank_selected_entry: default_yank_selected_entry(),
         }
     }
 }
@@ -415,6 +438,14 @@ fn default_toggle_help() -> Vec<String> {
 
 fn default_show_info() -> Vec<String> {
     vec!["enter".into()]
+}
+
+fn default_toggle_select_mode() -> Vec<String> {
+    vec!["f2".into()]
+}
+
+fn default_yank_selected_entry() -> Vec<String> {
+    vec!["y".into()]
 }
 
 #[cfg(test)]

--- a/fml/src/lib.rs
+++ b/fml/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod cli;
+pub mod clipboard;
 pub mod config;
 pub mod error;
 pub mod event;

--- a/fml/src/state/tui_state.rs
+++ b/fml/src/state/tui_state.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    time::{Duration, Instant},
+};
 
 use ratatui::layout::Rect;
 use ratatui_textarea::TextArea;
@@ -9,7 +12,6 @@ pub mod preview_pane_state;
 
 use log_pane_state::LogPaneState;
 use preview_pane_state::PreviewPaneState;
-use tui_popup::Popup;
 
 use crate::{
     config::{
@@ -85,6 +87,21 @@ pub struct TuiState {
     pub active_popup: Option<ActivePopup>,
     pub source_selector: SourceSelectorState,
     pub field_picker: FieldPickerState,
+    /// Transient status-bar message and the instant it was set.
+    pub status_message: Option<(String, Instant)>,
+    /// How long a transient status message remains visible.
+    pub status_message_ttl: Duration,
+    /// Next message to promote when the current one expires.
+    pub status_message_pending: Option<String>,
+    /// When `true`, mouse capture is released so the terminal handles
+    /// drag-selection and wheel scrollback.
+    pub select_mode: bool,
+    /// Set to `true` after the first yank in a multiplexer session so the
+    /// one-time clipboard-config hint is not repeated.
+    pub multiplexer_clipboard_hint_shown: bool,
+    /// When `true`, `status_message()` always returns `None`. Used by snapshot
+    /// tests to keep existing baselines stable.
+    pub suppress_status_messages: bool,
 }
 
 impl TuiState {
@@ -116,6 +133,12 @@ impl TuiState {
             active_popup: None,
             source_selector: SourceSelectorState::new(),
             field_picker: FieldPickerState::new(),
+            status_message: None,
+            status_message_ttl: Duration::from_secs(3),
+            status_message_pending: None,
+            select_mode: false,
+            multiplexer_clipboard_hint_shown: false,
+            suppress_status_messages: tui_config.suppress_status_messages,
         })
     }
 
@@ -346,5 +369,116 @@ impl TuiState {
 
     pub fn remove_source_id(&mut self, source_id: &SourceId) {
         self.source_selector.enabled_source_ids.remove(source_id);
+    }
+
+    /// Set a transient status-bar message, replacing any current message and
+    /// clearing the pending queue.
+    pub fn set_status_message(&mut self, msg: String) {
+        self.status_message = Some((msg, Instant::now()));
+        self.status_message_pending = None;
+    }
+
+    /// Queue a message to display after the current one expires. If there is no
+    /// current active message the queued message becomes current immediately.
+    pub fn queue_status_message(&mut self, msg: String) {
+        let now = Instant::now();
+        let active = self
+            .status_message
+            .as_ref()
+            .is_some_and(|(_, ts)| now.duration_since(*ts) < self.status_message_ttl);
+        if active {
+            self.status_message_pending = Some(msg);
+        } else {
+            self.status_message = Some((msg, now));
+        }
+    }
+
+    /// Return the current transient message if it is within its TTL, promoting
+    /// any pending message when the current one has expired.
+    ///
+    /// Returns `None` when there is no active message or when
+    /// `suppress_status_messages` is set.
+    pub fn status_message(&mut self, now: Instant) -> Option<&str> {
+        if self.suppress_status_messages {
+            return None;
+        }
+        let expired = self
+            .status_message
+            .as_ref()
+            .is_some_and(|(_, ts)| now.duration_since(*ts) >= self.status_message_ttl);
+        if expired {
+            if let Some(pending) = self.status_message_pending.take() {
+                self.status_message = Some((pending, now));
+            } else {
+                self.status_message = None;
+            }
+        }
+        self.status_message.as_ref().map(|(msg, _)| msg.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use crate::config::{search::SearchConfig, tui::TuiConfig};
+
+    use super::TuiState;
+
+    fn state() -> TuiState {
+        TuiState::new(&TuiConfig::default(), &SearchConfig::default()).unwrap()
+    }
+
+    #[test]
+    fn status_message_visible_within_ttl() {
+        let mut s = state();
+        s.set_status_message("hello".into());
+        let now = Instant::now();
+        assert_eq!(s.status_message(now), Some("hello"));
+    }
+
+    #[test]
+    fn status_message_expires_after_ttl() {
+        let mut s = state();
+        s.set_status_message("hello".into());
+        // Use the stored timestamp to compute a deterministic future instant.
+        let ts = s.status_message.as_ref().unwrap().1;
+        let after = ts + s.status_message_ttl + Duration::from_millis(1);
+        assert_eq!(s.status_message(after), None);
+    }
+
+    #[test]
+    fn suppress_status_messages_hides_message() {
+        let mut config = TuiConfig::default();
+        config.suppress_status_messages = true;
+        let mut s = TuiState::new(&config, &SearchConfig::default()).unwrap();
+        s.set_status_message("hello".into());
+        assert_eq!(s.status_message(Instant::now()), None);
+    }
+
+    #[test]
+    fn pending_message_promoted_when_current_expires() {
+        let mut s = state();
+        s.set_status_message("first".into());
+        s.queue_status_message("second".into());
+        // Before expiry: first is visible, pending queued.
+        let now = Instant::now();
+        assert_eq!(s.status_message(now), Some("first"));
+        // After expiry: pending is promoted.
+        let ts = s.status_message.as_ref().unwrap().1;
+        let after = ts + s.status_message_ttl + Duration::from_millis(1);
+        assert_eq!(s.status_message(after), Some("second"));
+    }
+
+    #[test]
+    fn set_status_message_clears_pending() {
+        let mut s = state();
+        s.set_status_message("first".into());
+        s.queue_status_message("second".into());
+        s.set_status_message("replaced".into());
+        let ts = s.status_message.as_ref().unwrap().1;
+        let after = ts + s.status_message_ttl + Duration::from_millis(1);
+        // Pending was cleared, so nothing after expiry.
+        assert_eq!(s.status_message(after), None);
     }
 }

--- a/fml/src/tui.rs
+++ b/fml/src/tui.rs
@@ -7,8 +7,8 @@ pub mod widgets;
 use crossterm::{
     ExecutableCommand as _,
     event::{
-        DisableMouseCapture, Event as CrosstermEvent, EventStream, KeyCode, KeyEventKind,
-        KeyModifiers,
+        DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent, EventStream, KeyCode,
+        KeyEventKind, KeyModifiers,
     },
     terminal::{LeaveAlternateScreen, disable_raw_mode},
 };
@@ -18,6 +18,7 @@ use tokio::{sync::mpsc, time::interval};
 use tracing::{debug, error, trace, warn};
 
 use crate::{
+    clipboard::OSC52_WARN_BYTES,
     config::tui::TuiConfig,
     error::FmlError,
     event::{Query, QuitEvent, SearchEvent, SearchTarget, TuiEvent},
@@ -166,6 +167,28 @@ pub fn handle_tui_event(event: TuiEvent, state: AppState) -> AppState {
 
             if custom_key == CustomizedKeyAction::TogglePreviewMode {
                 handle_preview_mode_toggle(&mut state);
+                return state;
+            }
+
+            if custom_key == CustomizedKeyAction::ToggleSelectMode {
+                state.tui.select_mode = !state.tui.select_mode;
+                // No widget currently consumes TuiEvent::Mouse, so releasing
+                // capture has no in-app functional regression today. The toggle
+                // is the first way users can get terminal wheel scrollback.
+                let mut out = stdout();
+                if state.tui.select_mode {
+                    let _ = out.execute(DisableMouseCapture);
+                } else {
+                    let _ = out.execute(EnableMouseCapture);
+                }
+                return state;
+            }
+
+            if custom_key == CustomizedKeyAction::YankSelectedEntry
+                && state.tui.focused == Slot::Main
+                && state.tui.active_popup().is_none()
+            {
+                handle_yank_selected_entry(&mut state);
                 return state;
             }
 
@@ -455,6 +478,46 @@ fn filtered_log_pane_sources(state: &AppState) -> Option<Vec<SourceId>> {
             .collect();
 
     (!source_ids.is_empty()).then_some(source_ids)
+}
+
+fn handle_yank_selected_entry(state: &mut AppState) {
+    let Some(selected) = state.tui.selected_entry.as_ref() else {
+        return; // silent no-op when nothing is selected
+    };
+    let json = serde_json::to_string(&*selected.entry).unwrap_or_default();
+    let mut out = stdout().lock();
+    let msg = match crate::clipboard::yank_osc52(&mut out, &json) {
+        Ok(n) if n > OSC52_WARN_BYTES => {
+            format!("sent yank ({n} bytes) — exceeds 8KB; xterm/vte may drop it")
+        }
+        Ok(n) => format!("sent yank ({n} bytes) — check clipboard"),
+        Err(e) => format!("yank failed: {e}"),
+    };
+    drop(out);
+    state.tui.set_status_message(msg);
+
+    if let Some(hint) = multiplexer_hint() {
+        if !state.tui.multiplexer_clipboard_hint_shown {
+            state.tui.multiplexer_clipboard_hint_shown = true;
+            state.tui.queue_status_message(hint);
+        }
+    }
+}
+
+/// Returns a one-time hint string when running inside a known multiplexer,
+/// or `None` when no multiplexer is detected.
+fn multiplexer_hint() -> Option<String> {
+    let in_tmux = std::env::var("TMUX").is_ok();
+    let in_zellij = std::env::var("ZELLIJ").is_ok();
+    match (in_tmux, in_zellij) {
+        (true, true) | (true, false) => {
+            Some("tmux: run `set -g set-clipboard on` to enable OSC52 yank".into())
+        }
+        (false, true) => {
+            Some("zellij: OSC52 yank needs an OSC52-capable host terminal or copy_command".into())
+        }
+        (false, false) => None,
+    }
 }
 
 fn apply_no_sources_selected(state: &mut AppState) {
@@ -1454,6 +1517,160 @@ mod tests {
             } => assert_eq!(target, SearchTarget::PreviewPane),
             event => panic!("expected surrounding preview search after picker skip, got {event:?}"),
         }
+    }
+
+    #[test]
+    fn toggle_select_mode_flips_state() {
+        let state = AppState::new(Config::default()).expect("app state");
+        assert!(!state.tui.select_mode);
+
+        let state = handle_tui_event(
+            TuiEvent::Input(KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE)),
+            state,
+        );
+        assert!(state.tui.select_mode);
+
+        let state = handle_tui_event(
+            TuiEvent::Input(KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE)),
+            state,
+        );
+        assert!(!state.tui.select_mode);
+    }
+
+    #[test]
+    fn yank_with_no_selection_is_silent_noop() {
+        let mut state = AppState::new(Config::default()).expect("app state");
+        state.tui.focused = Slot::Main;
+        assert!(state.tui.selected_entry.is_none());
+
+        let state = handle_tui_event(input(KeyCode::Char('y')), state);
+
+        assert!(state.tui.status_message.is_none());
+    }
+
+    #[tokio::test]
+    async fn yank_with_query_box_focused_does_not_trigger() {
+        let mut state = AppState::new(Config::default()).expect("app state");
+        state.tui.focused = Slot::QueryBox;
+        state.tui.selected_entry = Some(SelectedEntry {
+            entry: entry(1),
+            matches: Vec::new(),
+        });
+
+        let state = handle_tui_event(input(KeyCode::Char('y')), state);
+
+        assert!(state.tui.status_message.is_none());
+    }
+
+    #[test]
+    fn yank_with_selection_sets_status_message() {
+        let mut state = AppState::new(Config::default()).expect("app state");
+        state.tui.focused = Slot::Main;
+        state.tui.selected_entry = Some(SelectedEntry {
+            entry: entry(42),
+            matches: Vec::new(),
+        });
+
+        let state = handle_tui_event(input(KeyCode::Char('y')), state);
+
+        let msg = state.tui.status_message.as_ref().map(|(m, _)| m.as_str());
+        assert!(
+            msg.is_some_and(|m| m.contains("sent yank") && m.contains("bytes")),
+            "expected 'sent yank ... bytes' message, got {msg:?}"
+        );
+    }
+
+    #[test]
+    fn yank_with_popup_open_does_not_trigger() {
+        let mut state = AppState::new(Config::default()).expect("app state");
+        state.tui.focused = Slot::Main;
+        state.tui.selected_entry = Some(SelectedEntry {
+            entry: entry(1),
+            matches: Vec::new(),
+        });
+        state
+            .tui
+            .open_popup(crate::state::tui_state::ActivePopup::Help);
+
+        let state = handle_tui_event(input(KeyCode::Char('y')), state);
+
+        assert!(state.tui.status_message.is_none());
+    }
+
+    #[test]
+    fn multiplexer_hint_shown_flag_prevents_repeat() {
+        // Simulate multiplexer detection by pre-setting the shown flag. When the
+        // flag is already true, queue_status_message is never called regardless
+        // of $TMUX / $ZELLIJ env vars.
+        let mut state = AppState::new(Config::default()).expect("app state");
+        state.tui.focused = Slot::Main;
+        state.tui.selected_entry = Some(SelectedEntry {
+            entry: entry(1),
+            matches: Vec::new(),
+        });
+        state.tui.multiplexer_clipboard_hint_shown = true;
+
+        let state = handle_tui_event(input(KeyCode::Char('y')), state);
+        assert!(state.tui.status_message_pending.is_none());
+    }
+
+    #[test]
+    fn yank_status_message_normal_when_payload_is_small() {
+        // Small entry → well below the 8KB base64 threshold
+        let small_entry = entry_with_fields(
+            99,
+            std::collections::HashMap::from([("k".to_string(), json!("v"))]),
+        );
+        let mut state = AppState::new(Config::default()).expect("app state");
+        state.tui.focused = Slot::Main;
+        state.tui.selected_entry = Some(SelectedEntry {
+            entry: small_entry,
+            matches: Vec::new(),
+        });
+
+        let state = handle_tui_event(input(KeyCode::Char('y')), state);
+
+        let msg = state
+            .tui
+            .status_message
+            .as_ref()
+            .map(|(m, _)| m.as_str())
+            .unwrap_or("");
+        assert!(
+            !msg.contains("exceeds 8KB"),
+            "expected normal message for small payload, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn yank_status_message_warns_when_payload_exceeds_8kb_threshold() {
+        // Large pad field → well above the 8KB base64 threshold for any overhead
+        let large_entry = entry_with_fields(
+            99,
+            std::collections::HashMap::from([(
+                "pad".to_string(),
+                serde_json::Value::String("x".repeat(100_000)),
+            )]),
+        );
+        let mut state = AppState::new(Config::default()).expect("app state");
+        state.tui.focused = Slot::Main;
+        state.tui.selected_entry = Some(SelectedEntry {
+            entry: large_entry,
+            matches: Vec::new(),
+        });
+
+        let state = handle_tui_event(input(KeyCode::Char('y')), state);
+
+        let msg = state
+            .tui
+            .status_message
+            .as_ref()
+            .map(|(m, _)| m.as_str())
+            .unwrap_or("");
+        assert!(
+            msg.contains("exceeds 8KB"),
+            "expected 8KB warning message, got: {msg}"
+        );
     }
 
     #[test]

--- a/fml/src/tui/keybinds.rs
+++ b/fml/src/tui/keybinds.rs
@@ -34,6 +34,12 @@ pub enum CustomizedKeyAction {
     ScrollHead,
     /// Scroll to the bottom (tail)
     ScrollTail,
+    /// Toggle select mode: releases mouse capture so the terminal handles
+    /// drag-selection and wheel scrollback. Active in global scope.
+    ToggleSelectMode,
+    /// Yank the selected log entry as JSON via OSC 52. Only fires when the log
+    /// pane has focus and no popup is active.
+    YankSelectedEntry,
     /// A non-match
     None,
 }
@@ -138,6 +144,16 @@ pub const ACTION_HINTS: &[KeyActionHint] = &[
         label: "esc / ?",
         section: HelpSection::HelpPopup,
     },
+    KeyActionHint {
+        title: "Select mode",
+        label: "F2",
+        section: HelpSection::Global,
+    },
+    KeyActionHint {
+        title: "Yank entry",
+        label: "y",
+        section: HelpSection::LogPane,
+    },
 ];
 
 pub fn hints_for_section(section: HelpSection) -> impl Iterator<Item = &'static KeyActionHint> {
@@ -174,6 +190,8 @@ pub fn match_key(key: &KeyEvent, _focus: &Slot) -> (StaticKeyAction, CustomizedK
         }
         (KeyCode::Char('g') | KeyCode::Home, _) => CustomizedKeyAction::ScrollHead,
         (KeyCode::Char('G') | KeyCode::End, _) => CustomizedKeyAction::ScrollTail,
+        (KeyCode::F(2), _) => CustomizedKeyAction::ToggleSelectMode,
+        (KeyCode::Char('y'), _) => CustomizedKeyAction::YankSelectedEntry,
         _ => CustomizedKeyAction::None,
     };
 

--- a/fml/src/tui/widgets/status_bar.rs
+++ b/fml/src/tui/widgets/status_bar.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use ratatui::{
     layout::{Alignment, Constraint, Layout},
     style::Modifier,
@@ -75,14 +77,36 @@ impl FmlWidget for StatusBar {
         let key_style = base_style
             .fg(state.selected_theme.primary_accent_fg)
             .add_modifier(Modifier::BOLD);
-        let hints = self.visible_hints();
+
+        let now = Instant::now();
+        let transient = state.status_message(now).map(str::to_string);
+        let select_mode = state.select_mode;
+
         let mut spans = Vec::new();
-        for (index, hint) in hints.iter().enumerate() {
-            if index > 0 {
+
+        // A transient message (e.g. "sent yank … — check clipboard") replaces
+        // the normal keybind hints for its TTL. Once it expires the hints
+        // reappear automatically because status_message() returns None.
+        if let Some(msg) = transient {
+            spans.push(Span::styled(msg, key_style));
+        } else {
+            let hints = self.visible_hints();
+            for (index, hint) in hints.iter().enumerate() {
+                if index > 0 {
+                    spans.push(Span::styled(" | ", dim_style));
+                }
+                spans.push(Span::styled(format!("{} ", hint.title), dim_style));
+                spans.push(Span::styled(format!("<{}>", hint.label), key_style));
+            }
+        }
+
+        // [SELECT] is appended regardless of whether a transient message is
+        // shown so the mode indicator is always visible while active.
+        if select_mode {
+            if !spans.is_empty() {
                 spans.push(Span::styled(" | ", dim_style));
             }
-            spans.push(Span::styled(format!("{} ", hint.title), dim_style));
-            spans.push(Span::styled(format!("<{}>", hint.label), key_style));
+            spans.push(Span::styled("[SELECT]", key_style));
         }
 
         frame.render_widget(Block::default().style(base_style), area);


### PR DESCRIPTION
## Why

Getting text out of fml requires leaving the TUI to copy from a scrollback buffer, which breaks the debugging flow. This adds two complementary paths: a select-mode toggle that gives the host terminal control of mouse selection, and a yank shortcut that pushes the selected log entry directly to the system clipboard without any native library dependencies.

Closes #15

## What

- **F2 — select mode toggle**: releases crossterm mouse capture so the terminal handles native drag-selection and wheel scrollback. A `[SELECT]` indicator appears in the status bar while active. Re-pressing F2 restores in-app capture. Startup capture remains unconditional so the existing panic/exit teardown invariant is unchanged.
- **y — yank selected entry (log pane focused, no popup)**: serializes the current `LogEntry` as JSON and writes it to the system clipboard via an OSC 52 escape sequence. No X11/Wayland/clipboard library is added; `base64 = "0.22"` is the only new dependency.
- **Transient status-bar messages**: new `set_status_message` / `queue_status_message` / `status_message(now)` API on `TuiState`, with a 3-second TTL and a single pending slot for sequenced messages (e.g. yank confirmation followed by multiplexer hint).
- **8 KB warning**: payloads whose base64 encoding exceeds xterm/vte's documented cap produce a named warning in the status bar rather than silently failing.
- **Multiplexer hints**: first yank inside `$TMUX` or `$ZELLIJ` queues a one-time session hint about the clipboard config required for OSC 52 delivery.
- **Help popup / keybindings config**: `ToggleSelectMode` and `YankSelectedEntry` appear in their respective help sections and are configurable under `[tui.keybindings]`.

## Acceptance criteria

- [x] F2 toggles mouse capture and shows/hides `[SELECT]`.
- [x] Quit, panic, and normal exit always leave the terminal with capture off.
- [x] `y` with log pane focused and a selected entry writes OSC 52 and shows status.
- [x] `y` with no selection is a silent no-op.
- [x] `y` with query box focused inserts the character normally.
- [x] `y` with any popup open is swallowed by popup handlers.
- [x] Payloads over 8 KB get the named warning.
- [x] Multiplexer hint fires once per session, not on every yank.
- [x] Status message auto-expires after 3 s; keybind hints reappear.

## Verification

- `cargo test --workspace` (322 tests, 0 failures; pre-commit hook ran on commit)
- `cargo clippy --workspace --all-targets` (0 new errors or warnings)
- Manual matrix: Not run — see plan at `docs/plans/yank-bigplan.md` for the full terminal × multiplexer matrix that should be checked before merge.

## Review focus

- **OSC 52 is best-effort**: the status bar says "sent yank" not "copied" because there is no in-band confirmation. macOS Terminal.app, old GNOME Terminal/VTE, and Windows Console Host silently drop the sequence. The README update (Deliverable 4 from the plan) is tracked separately.
- **`suppress_status_messages` on `TuiConfig`**: adds a flag (default `false`) so snapshot tests can opt out of transient messages without requiring sleeps or mocking time. No existing snapshots are currently affected.
- **`multiplexer_hint()` reads env vars directly**: `$TMUX` and `$ZELLIJ` are the standard signals their respective multiplexers set for nested processes. No config override is provided; this is documented in the plan as intentional for this slice.
- **`status_message(now: Instant)` vs. `set/queue_status_message()`**: the read accessor takes `now` so unit tests can simulate TTL expiry deterministically (read the stored timestamp, add TTL + 1 ms) without sleeping. The mutating methods use `Instant::now()` internally since callers always mean "right now".
