### PR TITLE
feat(tui): per-pane line wrapping for the log view

### DIFF
--- a/fml/src/config/tui.rs
+++ b/fml/src/config/tui.rs
@@ -52,12 +52,14 @@ pub struct TuiConfig {
     #[serde(default)]
     pub suppress_status_messages: bool,
 
-    /// Startup default for line wrapping in the log and preview panes.
+    /// Startup default for line wrapping in log panes.
     ///
     /// When `true`, long log entries wrap onto continuation lines indented
     /// under the `msg` column. When `false` (default), entries render on a
-    /// single line and are clipped to the pane width. Toggle at runtime with
-    /// the `toggle_line_wrap` keybinding; the flag is shared by both panes.
+    /// single line and are clipped to the pane width. This is only the startup
+    /// seed: wrapping is a **per-pane** runtime flag, toggled with `:wrap`
+    /// (`:set wrap`/`:set nowrap`) or the hardcoded `W` key, and each split
+    /// inherits the wrap state of the pane it was cloned from.
     #[serde(default)]
     pub line_wrap: bool,
 }
@@ -457,9 +459,11 @@ pub struct KeybindingsConfig {
 
     /// Toggle line-wrap mode for the log pane.
     ///
-    /// Only fires when the log pane has focus. Flips between single-line
-    /// truncated rendering and wrapped rendering with hanging-indent
-    /// continuation lines under the `msg` column.
+    /// **Not yet consulted by dispatch.** Like the rest of
+    /// [`KeybindingsConfig`], this field is advisory scaffolding — dispatch is
+    /// hardcoded, and line wrap is bound to a fixed `W` key (plus the `:wrap`
+    /// command). The default below documents that real key; overriding it has
+    /// no effect until configurable keybindings are wired.
     #[serde(default = "default_toggle_line_wrap")]
     pub toggle_line_wrap: Vec<String>,
 }
@@ -513,7 +517,9 @@ fn default_yank_selected_entry() -> Vec<String> {
 }
 
 fn default_toggle_line_wrap() -> Vec<String> {
-    vec!["w".into()]
+    // Hardcoded dispatch uses shift+`W` (`w` is word-forward); this advisory
+    // default matches the real key even though the field is not consulted.
+    vec!["W".into()]
 }
 
 #[cfg(test)]
@@ -531,8 +537,10 @@ mod tests {
     }
 
     #[test]
-    fn default_toggle_line_wrap_binding_is_w() {
+    fn default_toggle_line_wrap_binding_matches_hardcoded_key() {
+        // Advisory only (dispatch is hardcoded), but the default must match the
+        // real `W` key rather than the dead `w` (word-forward) it once claimed.
         let kb = KeybindingsConfig::default();
-        assert_eq!(kb.toggle_line_wrap, vec!["w".to_string()]);
+        assert_eq!(kb.toggle_line_wrap, vec!["W".to_string()]);
     }
 }

--- a/fml/src/state.rs
+++ b/fml/src/state.rs
@@ -26,12 +26,13 @@ pub struct AppState {
 impl AppState {
     pub fn new(config: Config) -> Result<Self, FmlError> {
         let theme = config.tui.resolved_theme_with(&config.themes)?;
+        let line_wrap = config.tui.line_wrap;
         Ok(AppState {
             store: RingBufferStore::new(config.store.clone()),
             config,
             theme,
             event_bus: EventBus::new(),
-            workspace: Workspace::new(),
+            workspace: Workspace::new(line_wrap),
             search: SearchState::new(),
             producer: ProducerState::new(),
         })

--- a/fml/src/tui.rs
+++ b/fml/src/tui.rs
@@ -18,6 +18,7 @@ use ratatui::{Terminal, backend::Backend, layout::Direction};
 use tokio::{sync::mpsc, time::interval};
 use tracing::{debug, error, warn};
 
+pub mod layout;
 pub mod pane;
 pub mod render;
 pub mod workspace;
@@ -473,6 +474,8 @@ fn handle_normal_key(state: &mut AppState, key: KeyEvent) {
 
     match (key.code, ctrl) {
         (KeyCode::Char('w'), true) => state.workspace.pending.prefix = Some(Prefix::Window),
+        // `W` (shift+w) toggles wrap; `w` (word-forward) is handled in motions.
+        (KeyCode::Char('W'), false) => state.workspace.focused_pane_mut().toggle_line_wrap(),
         (KeyCode::Char('F'), false) => {
             let (ws, ctx) = split_state(state);
             ws.focused_pane_mut().enter_follow(&ctx);
@@ -694,7 +697,7 @@ fn handle_command_key(state: &mut AppState, key: KeyEvent) {
 /// Command names offered by first-token completion.
 const COMMAND_NAMES: &[&str] = &[
     "filter", "sources", "vsplit", "split", "hsplit", "tabnew", "tabclose", "tabnext", "tabprev",
-    "tail", "refresh", "clear", "only", "help", "quit", "qa",
+    "tail", "refresh", "clear", "only", "help", "quit", "qa", "wrap", "set",
 ];
 
 /// Vim-style `:` completion. The first Tab gathers candidates for the
@@ -789,9 +792,10 @@ fn execute_command(state: &mut AppState, line: &str) {
             }
         }
         "tabnew" => {
+            let line_wrap = state.config.tui.line_wrap;
             state
                 .workspace
-                .new_tab((!args.is_empty()).then(|| args.join(" ")));
+                .new_tab((!args.is_empty()).then(|| args.join(" ")), line_wrap);
             let (ws, ctx) = split_state(state);
             dispatch_pane_current(ws.focused_pane_mut(), &ctx);
         }
@@ -837,6 +841,17 @@ fn execute_command(state: &mut AppState, line: &str) {
                 pane.results_to_stream(&ctx);
             }
         }
+        "wrap" => {
+            state.workspace.focused_pane_mut().toggle_line_wrap();
+        }
+        // `:set` is not a general option namespace — only wrap/nowrap.
+        "set" => match args.first().copied() {
+            Some("wrap") => state.workspace.focused_pane_mut().line_wrap = true,
+            Some("nowrap") => state.workspace.focused_pane_mut().line_wrap = false,
+            _ => {
+                state.workspace.notice = Some("usage: :set wrap | :set nowrap".to_string());
+            }
+        },
         "sources" | "src" | "ls" => open_source_picker(state),
         "help" | "h" => state.workspace.help_open = true,
         unknown => {
@@ -1036,6 +1051,83 @@ mod tests {
         let state = handle_tui_event(input(KeyCode::Char('k')), state);
 
         assert_eq!(state.workspace.focused_pane().cursor_seq, Some(8));
+    }
+
+    #[test]
+    fn shift_w_toggles_line_wrap_on_active_pane() {
+        let mut state = state_with_entries(3);
+        seed_tail(&mut state, &[1, 2, 3]);
+        assert!(!state.workspace.focused_pane().line_wrap);
+
+        let shift_w = || TuiEvent::Input(KeyEvent::new(KeyCode::Char('W'), KeyModifiers::SHIFT));
+        let state = handle_tui_event(shift_w(), state);
+        assert!(state.workspace.focused_pane().line_wrap);
+        let state = handle_tui_event(shift_w(), state);
+        assert!(!state.workspace.focused_pane().line_wrap);
+    }
+
+    #[test]
+    fn lowercase_w_is_word_forward_not_wrap() {
+        let mut state = state_with_entries(3);
+        seed_tail(&mut state, &[1, 2, 3]);
+
+        let state = handle_tui_event(input(KeyCode::Char('w')), state);
+
+        // `w` must remain word-forward and leave wrap untouched.
+        assert!(!state.workspace.focused_pane().line_wrap);
+    }
+
+    #[test]
+    fn wrap_command_toggles_and_set_is_idempotent() {
+        let mut state = state_with_entries(3);
+        seed_tail(&mut state, &[1, 2, 3]);
+
+        execute_command(&mut state, "wrap");
+        assert!(state.workspace.focused_pane().line_wrap);
+        execute_command(&mut state, "wrap");
+        assert!(!state.workspace.focused_pane().line_wrap);
+
+        execute_command(&mut state, "set wrap");
+        execute_command(&mut state, "set wrap");
+        assert!(
+            state.workspace.focused_pane().line_wrap,
+            ":set wrap is idempotent"
+        );
+        execute_command(&mut state, "set nowrap");
+        execute_command(&mut state, "set nowrap");
+        assert!(
+            !state.workspace.focused_pane().line_wrap,
+            ":set nowrap is idempotent"
+        );
+    }
+
+    #[test]
+    fn set_without_known_arg_reports_usage() {
+        let mut state = state_with_entries(1);
+        execute_command(&mut state, "set bogus");
+        assert!(
+            state
+                .workspace
+                .notice
+                .as_deref()
+                .unwrap_or("")
+                .contains("set wrap")
+        );
+        assert!(!state.workspace.focused_pane().line_wrap);
+    }
+
+    #[test]
+    fn startup_default_seeds_pane_line_wrap() {
+        let mut config = Config::default();
+        config.tui.line_wrap = true;
+        let state = AppState::new(config).expect("app state");
+        assert!(state.workspace.focused_pane().line_wrap);
+    }
+
+    #[test]
+    fn command_names_include_wrap_and_set_for_completion() {
+        assert!(COMMAND_NAMES.contains(&"wrap"));
+        assert!(COMMAND_NAMES.contains(&"set"));
     }
 
     #[test]

--- a/fml/src/tui/layout.rs
+++ b/fml/src/tui/layout.rs
@@ -1,0 +1,271 @@
+//! Pure display-layout math for the log view.
+//!
+//! Navigation and selection stay entry/logical-based on the flat
+//! [`row_text`](super::pane::row_text); the only place a logical char offset is
+//! turned into a `(display_row, display_col)` position is at render time. This
+//! module is that single source of truth — no rendering, no pane state, just
+//! the wrap arithmetic, so it can be exhaustively unit-tested.
+//!
+//! Wrapping is **greedy char-wrap**: rows break exactly at the usable width
+//! using Rust `char` offsets as the unit. It is intentionally **not**
+//! terminal-cell/grapheme aware, so wide characters, emoji, and combining
+//! marks may misalign — the same limitation the truncation and yank paths
+//! already carry.
+
+/// One rendered display row of an entry.
+///
+/// `start_col..end_col` is the half-open logical char range (offsets into the
+/// entry's `row_text`) this row shows. `indent` is the render-column offset at
+/// which that text is drawn: `0` on the first row of an entry, the hanging
+/// indent on continuation rows. Consumers must use this `indent` rather than
+/// recomputing it, so per-char highlights line up on continuation rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DisplayRow {
+    pub start_col: usize,
+    pub end_col: usize,
+    pub indent: usize,
+}
+
+impl DisplayRow {
+    /// Number of logical chars this row shows.
+    pub fn len(&self) -> usize {
+        self.end_col - self.start_col
+    }
+
+    /// Whether the row carries no logical chars (an empty entry).
+    pub fn is_empty(&self) -> bool {
+        self.end_col == self.start_col
+    }
+}
+
+/// Lay `text` out into ordered display rows for a content area `width` chars
+/// wide, using `indent` as the continuation-row hanging indent.
+///
+/// With `wrap` off this returns exactly one row truncated to `width`,
+/// reproducing the historical `.chars().take(width)` behavior. With `wrap` on
+/// the first row spans the full `width` and continuation rows are shifted right
+/// by the effective indent (`min(indent, width - 1)`), with at least one usable
+/// content cell whenever `width > 0`.
+pub fn layout_entry(text: &str, width: usize, indent: usize, wrap: bool) -> Vec<DisplayRow> {
+    let len = text.chars().count();
+
+    if !wrap {
+        return vec![DisplayRow {
+            start_col: 0,
+            end_col: len.min(width),
+            indent: 0,
+        }];
+    }
+
+    // Degenerate zero-width area: nothing is renderable, but still return one
+    // row so the renderer always has a row per entry.
+    if width == 0 {
+        return vec![DisplayRow {
+            start_col: 0,
+            end_col: 0,
+            indent: 0,
+        }];
+    }
+
+    // First row uses the full width with no indent.
+    let first_end = len.min(width);
+    let mut rows = vec![DisplayRow {
+        start_col: 0,
+        end_col: first_end,
+        indent: 0,
+    }];
+    let mut col = first_end;
+    if col >= len {
+        return rows;
+    }
+
+    // Continuation rows: shift right by the indent, keeping at least one cell.
+    let eff_indent = indent.min(width.saturating_sub(1));
+    let usable = (width - eff_indent).max(1);
+    while col < len {
+        let end = (col + usable).min(len);
+        rows.push(DisplayRow {
+            start_col: col,
+            end_col: end,
+            indent: eff_indent,
+        });
+        col = end;
+    }
+    rows
+}
+
+/// Map a logical char offset to `(row_index, display_col)` within `rows`.
+///
+/// `display_col` already includes the row's indent. Offsets past the end of
+/// the text are clamped onto the last char cell, so callers can feed a sticky
+/// cursor column without bounds-checking first. `rows` must be non-empty (every
+/// [`layout_entry`] result is).
+pub fn col_to_display(rows: &[DisplayRow], col: usize) -> (usize, usize) {
+    if rows.is_empty() {
+        return (0, 0);
+    }
+    let len = rows[rows.len() - 1].end_col;
+    let col = col.min(len.saturating_sub(1));
+    for (idx, row) in rows.iter().enumerate() {
+        if col < row.end_col || idx == rows.len() - 1 {
+            return (idx, row.indent + col.saturating_sub(row.start_col));
+        }
+    }
+    (0, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(start: usize, end: usize, indent: usize) -> DisplayRow {
+        DisplayRow {
+            start_col: start,
+            end_col: end,
+            indent,
+        }
+    }
+
+    #[test]
+    fn wrap_off_truncates_to_one_row() {
+        // Long text, narrow width: a single row clipped to width, no indent.
+        let rows = layout_entry("hello world", 5, 4, false);
+        assert_eq!(rows, vec![row(0, 5, 0)]);
+    }
+
+    #[test]
+    fn wrap_off_short_line_keeps_full_text() {
+        let rows = layout_entry("hi", 10, 4, false);
+        assert_eq!(rows, vec![row(0, 2, 0)]);
+    }
+
+    #[test]
+    fn wrap_on_short_line_is_one_row() {
+        let rows = layout_entry("hi", 10, 4, true);
+        assert_eq!(rows, vec![row(0, 2, 0)]);
+    }
+
+    #[test]
+    fn wrap_on_exact_width_boundary_is_one_row() {
+        // Text exactly fills the first row; no empty continuation row.
+        let rows = layout_entry("abcde", 5, 2, true);
+        assert_eq!(rows, vec![row(0, 5, 0)]);
+    }
+
+    #[test]
+    fn wrap_on_multi_row_with_hanging_indent() {
+        // width 10, indent 4 → first row 10 chars, continuations 6 chars each.
+        let text: String = ('a'..='z').collect(); // 26 chars
+        let rows = layout_entry(&text, 10, 4, true);
+        assert_eq!(
+            rows,
+            vec![
+                row(0, 10, 0),
+                row(10, 16, 4),
+                row(16, 22, 4),
+                row(22, 26, 4)
+            ]
+        );
+    }
+
+    #[test]
+    fn wrap_on_empty_text_is_one_empty_row() {
+        let rows = layout_entry("", 10, 4, true);
+        assert_eq!(rows, vec![row(0, 0, 0)]);
+        assert!(rows[0].is_empty());
+    }
+
+    #[test]
+    fn wrap_on_width_equal_to_indent_keeps_one_usable_cell() {
+        // width == indent: effective indent saturates to width-1 so at least
+        // one content cell remains and the layout cannot loop forever.
+        let rows = layout_entry("abcd", 4, 4, true);
+        // First row: 4 chars. Continuation: indent 3, usable 1.
+        assert_eq!(rows[0], row(0, 4, 0));
+        // "abcd" is exactly width, so it fits in one row here.
+        assert_eq!(rows.len(), 1);
+
+        // Now force a continuation by exceeding the first row.
+        let rows = layout_entry("abcdef", 4, 4, true);
+        assert_eq!(rows[0], row(0, 4, 0));
+        for cont in &rows[1..] {
+            assert_eq!(cont.indent, 3);
+            assert_eq!(cont.len(), 1);
+        }
+        assert_eq!(rows.last().unwrap().end_col, 6);
+    }
+
+    #[test]
+    fn wrap_on_width_smaller_than_indent_saturates() {
+        let rows = layout_entry("abcdef", 3, 10, true);
+        assert_eq!(rows[0], row(0, 3, 0));
+        // effective indent clamped to width-1 = 2, usable = 1.
+        for cont in &rows[1..] {
+            assert_eq!(cont.indent, 2);
+            assert_eq!(cont.len(), 1);
+        }
+        assert_eq!(rows.last().unwrap().end_col, 6);
+    }
+
+    #[test]
+    fn wrap_on_zero_width_is_one_empty_row() {
+        let rows = layout_entry("abc", 0, 4, true);
+        assert_eq!(rows, vec![row(0, 0, 0)]);
+    }
+
+    #[test]
+    fn col_to_display_within_first_row() {
+        let rows = layout_entry("abcdefghij", 10, 4, true);
+        assert_eq!(col_to_display(&rows, 0), (0, 0));
+        assert_eq!(col_to_display(&rows, 3), (0, 3));
+    }
+
+    #[test]
+    fn col_to_display_at_row_boundaries() {
+        // rows: [0,10) indent 0, [10,16) indent 4, ...
+        let text: String = ('a'..='z').collect();
+        let rows = layout_entry(&text, 10, 4, true);
+        // col 9 is the last cell of row 0.
+        assert_eq!(col_to_display(&rows, 9), (0, 9));
+        // col 10 is the first cell of the first continuation row, offset by 4.
+        assert_eq!(col_to_display(&rows, 10), (1, 4));
+        // col 16 starts the second continuation row.
+        assert_eq!(col_to_display(&rows, 16), (2, 4));
+    }
+
+    #[test]
+    fn col_to_display_past_end_clamps_to_last_cell() {
+        let text: String = ('a'..='z').collect(); // last row [22,26)
+        let rows = layout_entry(&text, 10, 4, true);
+        // col way past end clamps onto the last char (col 25) of the last row.
+        assert_eq!(col_to_display(&rows, 999), (3, 4 + (25 - 22)));
+    }
+
+    #[test]
+    fn col_to_display_empty_text() {
+        let rows = layout_entry("", 10, 4, true);
+        assert_eq!(col_to_display(&rows, 0), (0, 0));
+        assert_eq!(col_to_display(&rows, 5), (0, 0));
+    }
+
+    #[test]
+    fn col_to_display_wrap_off_truncated() {
+        // Wrap off: one row clipped to width. A cursor past width clamps onto
+        // the last visible cell (the pre-existing off-screen quirk is a render
+        // concern; the mapping itself stays in range).
+        let rows = layout_entry("abcdefghij", 5, 4, false);
+        assert_eq!(col_to_display(&rows, 2), (0, 2));
+        assert_eq!(col_to_display(&rows, 9), (0, 4));
+    }
+
+    #[test]
+    fn unicode_is_treated_as_chars_not_cells() {
+        // Known limitation: layout counts Rust chars, not terminal cells. A
+        // wide char occupies one logical column here.
+        let rows = layout_entry("a😀b😀c", 3, 1, true);
+        // 5 chars, width 3 → first row 3 chars, continuation 2 chars.
+        assert_eq!(rows[0], row(0, 3, 0));
+        assert_eq!(rows[1].start_col, 3);
+        assert_eq!(rows[1].end_col, 5);
+    }
+}

--- a/fml/src/tui/pane.rs
+++ b/fml/src/tui/pane.rs
@@ -238,6 +238,11 @@ impl Pane {
     /// new mode on the next frame.
     pub fn toggle_line_wrap(&mut self) {
         self.line_wrap = !self.line_wrap;
+        // Turning wrap on while following: snap so the newest entry shows its
+        // last display row rather than wrapping a tall entry from row 0.
+        if self.line_wrap && self.follow {
+            self.snap_col_to_row_end();
+        }
     }
 
     /// The entry under the cursor, if any.
@@ -391,6 +396,9 @@ impl Pane {
                     // Live search: ride the newest match like a tail stream so
                     // the cursor stays on the freshest hit as results re-rank.
                     self.cursor_seq = entries.last().map(|entry| entry.seq);
+                    // Keep the cursor on the newest entry's last display row so
+                    // wrapping a tall fresh match shows its tail, not row 0.
+                    self.snap_col_to_row_end();
                 } else {
                     // Frozen search: keep the cursor on its row when the entry
                     // is still present, else fall back to the nearest match.
@@ -415,6 +423,9 @@ impl Pane {
             _ => {
                 if self.follow {
                     self.cursor_seq = entries.last().map(|entry| entry.seq);
+                    // Tail/startup: land on the newest entry's last display row
+                    // when wrapping so a tall fresh entry isn't clipped at row 0.
+                    self.snap_col_to_row_end();
                 } else {
                     self.cursor_seq = self
                         .cursor_seq
@@ -1895,5 +1906,61 @@ mod tests {
 
         let selected: Vec<u64> = pane.selection(4).iter().map(|e| e.seq).collect();
         assert_eq!(selected, vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn follow_results_snap_col_when_wrapping() {
+        // A following pane that advances to a fresh tall entry must park the
+        // sticky column past the line end so wrapping shows the entry's last
+        // display row, not row 0. Covers tail/startup result application.
+        let mut pane = Pane::new(PaneId(1));
+        pane.line_wrap = true;
+        pane.cursor_col = 0;
+        let query = Query::Tail;
+        pane.active_query = Some(query.clone());
+        pane.apply_result(
+            &query,
+            entries(&[1, 2, 3]),
+            HashMap::new(),
+            None,
+            None,
+            true,
+            (1, 3),
+        );
+        assert!(pane.follow);
+        assert_eq!(pane.cursor_col, usize::MAX, "follow snaps to row end");
+
+        // Wrap off leaves the column untouched (render path stays unchanged).
+        let mut pane = Pane::new(PaneId(1));
+        pane.cursor_col = 0;
+        pane.active_query = Some(query.clone());
+        pane.apply_result(
+            &query,
+            entries(&[1, 2, 3]),
+            HashMap::new(),
+            None,
+            None,
+            true,
+            (1, 3),
+        );
+        assert_eq!(pane.cursor_col, 0, "wrap off is a no-op snap");
+    }
+
+    #[test]
+    fn toggle_wrap_on_while_following_snaps_col() {
+        let mut pane = Pane::new(PaneId(1));
+        pane.cursor_col = 0;
+        assert!(pane.follow && !pane.line_wrap);
+
+        pane.toggle_line_wrap();
+        assert_eq!(pane.cursor_col, usize::MAX, "wrap-on while following snaps");
+
+        // Toggling back off should not re-snap, and a non-following pane keeps
+        // its column when wrap is toggled.
+        let mut pane = Pane::new(PaneId(1));
+        pane.follow = false;
+        pane.cursor_col = 7;
+        pane.toggle_line_wrap();
+        assert_eq!(pane.cursor_col, 7, "no snap when not following");
     }
 }

--- a/fml/src/tui/pane.rs
+++ b/fml/src/tui/pane.rs
@@ -61,6 +61,36 @@ pub struct SearchCtx<'a> {
     pub bounds: (u64, u64),
 }
 
+/// Scroll position of a pane's log view.
+///
+/// Kept typed so the wrap-off (entry-index) and wrap-on (display-row) meanings
+/// can never be silently confused when toggling wrap, cloning on split, or
+/// reading the anchor in the renderer. The renderer normalizes the anchor to
+/// the pane's current `line_wrap` mode each frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScrollAnchor {
+    /// Wrap off: index of the first visible entry.
+    Entry(usize),
+    /// Wrap on: the first visible display row, as the entry index plus the
+    /// display-row offset within that entry.
+    Display { entry: usize, row: usize },
+}
+
+impl ScrollAnchor {
+    /// The first visible entry index, regardless of variant.
+    pub fn entry(self) -> usize {
+        match self {
+            Self::Entry(entry) | Self::Display { entry, .. } => entry,
+        }
+    }
+}
+
+impl Default for ScrollAnchor {
+    fn default() -> Self {
+        Self::Entry(0)
+    }
+}
+
 /// What the pane is currently displaying.
 pub enum View {
     /// A contiguous window of the filtered store (tail or history query).
@@ -119,8 +149,12 @@ pub struct Pane {
     pub empty_note: Option<String>,
     /// Last rendered content area; drives paging sizes and directional focus.
     pub rect: Rect,
-    /// First visible row offset, kept across renders for scroll stability.
-    pub scroll: usize,
+    /// Scroll position, kept across renders for stability. Typed so the
+    /// wrap-off (entry) and wrap-on (display-row) meanings never collide.
+    pub scroll: ScrollAnchor,
+    /// Wrap long entries across continuation rows (per-pane runtime toggle).
+    /// Seeded from `TuiConfig.line_wrap`; flipped by `:wrap`/`W`.
+    pub line_wrap: bool,
     /// Whether the detail overlay (full entry JSON) is open.
     pub detail_open: bool,
     pub detail_scroll: u16,
@@ -146,7 +180,8 @@ impl Pane {
             last_history_center: None,
             empty_note: None,
             rect: Rect::default(),
-            scroll: 0,
+            scroll: ScrollAnchor::default(),
+            line_wrap: false,
             detail_open: false,
             detail_scroll: 0,
         }
@@ -191,9 +226,18 @@ impl Pane {
             empty_note: self.empty_note.clone(),
             rect: Rect::default(),
             scroll: self.scroll,
+            // Splits inherit the current pane's wrap state.
+            line_wrap: self.line_wrap,
             detail_open: false,
             detail_scroll: 0,
         }
+    }
+
+    /// Flip line wrapping for this pane. Splits inherit the new state via
+    /// [`Pane::clone_into`]; the renderer normalizes the scroll anchor to the
+    /// new mode on the next frame.
+    pub fn toggle_line_wrap(&mut self) {
+        self.line_wrap = !self.line_wrap;
     }
 
     /// The entry under the cursor, if any.
@@ -473,7 +517,20 @@ impl Pane {
     }
 
     pub fn goto_bottom(&mut self, ctx: &SearchCtx) {
+        self.snap_col_to_row_end();
         self.jump_to(ctx.bounds.1, ctx);
+    }
+
+    /// When wrapping, park the sticky column past the end of the line so the
+    /// cursor lands on the newest entry's *last* display row — otherwise tail
+    /// would show the first display row of a tall newest entry and clip the
+    /// rest. The effective column clamps to the row's last char, so a sentinel
+    /// is enough and stays correct as the newest entry changes. No-op with
+    /// wrap off, keeping that render path byte-for-byte unchanged.
+    fn snap_col_to_row_end(&mut self) {
+        if self.line_wrap {
+            self.cursor_col = usize::MAX;
+        }
     }
 
     /// Re-enter follow (TAIL) mode. View-aware: on an active fuzzy results
@@ -481,6 +538,7 @@ impl Pane {
     /// matches, staying in results); on a plain stream it tails the stream.
     pub fn enter_follow(&mut self, ctx: &SearchCtx) {
         self.follow = true;
+        self.snap_col_to_row_end();
         let fuzzy_term = match &self.view {
             View::Results { term, .. } if !term.is_empty() => Some(term.clone()),
             _ => None,
@@ -1782,6 +1840,37 @@ mod tests {
             rx.try_recv().is_err(),
             "no dispatch when nothing to refresh"
         );
+    }
+
+    #[test]
+    fn charwise_selection_text_is_wrap_independent() {
+        // Wrapping is render-only: a charwise selection spanning what would be
+        // a wrap boundary still yanks the exact contiguous `row_text` slice.
+        let mut pane = Pane::new(PaneId(1));
+        pane.line_wrap = true;
+        let e = Arc::new(LogEntry {
+            seq: 1,
+            msg: "abcdefghijklmnopqrstuvwxyz0123456789".to_string(),
+            ts: Utc::now(),
+            level: Some(LogLevel::Info),
+            source: Source {
+                producer: "p".to_string(),
+                id: "s".to_string(),
+                display_name: "src".to_string(),
+                group: None,
+            },
+            fields: HashMap::new(),
+        });
+        pane.view = View::Stream {
+            entries: vec![e.clone()],
+        };
+        pane.cursor_seq = Some(1);
+        pane.cursor_col = 45;
+
+        // Select cols 35..=45 — a span that straddles a 40-col wrap boundary.
+        let got = pane.charwise_selection_text(1, 35);
+        let expected: String = row_text(&e).chars().skip(35).take(45 - 35 + 1).collect();
+        assert_eq!(got, expected);
     }
 
     #[test]

--- a/fml/src/tui/render.rs
+++ b/fml/src/tui/render.rs
@@ -268,7 +268,10 @@ fn draw_pane(
     };
 
     // An entry can occupy several consecutive display rows; compute its full
-    // per-char style buffer once and slice each display row out of it.
+    // per-char style buffer once and slice each display row out of it. Wrap off
+    // only ever shows one display row truncated to `width`, so cap the styled
+    // span there instead of styling the whole (possibly tens-of-KB) log line.
+    let style_limit = if pane.line_wrap { usize::MAX } else { width };
     let mut lines: Vec<Line> = Vec::with_capacity(height);
     let mut cached: Option<(usize, Vec<char>, Vec<Style>, Style)> = None;
     for (entry_idx, drow) in visible {
@@ -284,6 +287,7 @@ fn draw_pane(
                 matches,
                 is_cursor_row,
                 effective_col,
+                style_limit,
             );
             cached = Some((entry_idx, chars, styles, row_bg));
         }
@@ -309,6 +313,10 @@ fn draw_pane(
 /// with. The block cursor's reversed cell is patched at `effective_col`; with
 /// wrap off, a column past the pane width stays out of the single visible slice
 /// (the pre-existing off-screen-cursor behavior, unchanged).
+///
+/// `limit` caps how many leading chars are collected and styled. Wrap on passes
+/// `usize::MAX` (the wrap renderer may slice any display row); wrap off passes
+/// the pane width so the bounded single-row work is preserved.
 #[allow(clippy::too_many_arguments)]
 fn entry_row_styles(
     entry: &LogEntry,
@@ -319,8 +327,9 @@ fn entry_row_styles(
     matches: Option<&HashMap<u64, Vec<Match>>>,
     is_cursor_row: bool,
     effective_col: usize,
+    limit: usize,
 ) -> (Vec<char>, Vec<Style>, Style) {
-    let chars: Vec<char> = row_text(entry).chars().collect();
+    let chars: Vec<char> = row_text(entry).chars().take(limit).collect();
     let level_style = Style::default().fg(theme.log_row_fg(entry.level));
     let dim = Style::default().fg(theme.border_unfocused_fg);
 

--- a/fml/src/tui/render.rs
+++ b/fml/src/tui/render.rs
@@ -7,6 +7,8 @@
 //! visual selection, and fuzzy-match highlights compose over the same
 //! [`row_text`] the yank path copies — what you see is what you yank.
 
+use std::{collections::HashMap, sync::Arc};
+
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
@@ -17,10 +19,13 @@ use ratatui::{
 
 use crate::{
     config::tui::ThemeConfig,
+    event::Match,
+    log::LogEntry,
     state::AppState,
     store::StoreStats,
     tui::{
-        pane::{MSG_CHAR_OFFSET, Pane, View, row_text},
+        layout::{DisplayRow, col_to_display, layout_entry},
+        pane::{MSG_CHAR_OFFSET, Pane, ScrollAnchor, View, row_text},
         workspace::{Mode, Prompt},
     },
 };
@@ -218,123 +223,366 @@ fn draw_pane(
     }
 
     let height = content.height as usize;
+    let width = content.width as usize;
     let cursor_idx = pane.cursor_index().unwrap_or(entries.len() - 1);
+    let effective_col = pane.effective_col();
 
-    // Keep the cursor on screen with a small scrolloff margin.
-    let mut scroll = pane.scroll.min(entries.len().saturating_sub(1));
-    if cursor_idx < scroll + SCROLLOFF {
-        scroll = cursor_idx.saturating_sub(SCROLLOFF);
-    }
-    if cursor_idx + SCROLLOFF >= scroll + height {
-        scroll = (cursor_idx + SCROLLOFF + 1).saturating_sub(height);
-    }
-    scroll = scroll.min(entries.len().saturating_sub(height.min(entries.len())));
-    pane.scroll = scroll;
+    // Lay out the visible window as `(entry_index, display_row)` pairs and
+    // persist the matching scroll anchor. Wrap off keeps the historical
+    // entry-index scroll (one truncated row per entry, byte-for-byte); wrap on
+    // walks display rows so the cursor's display row stays on screen.
+    let (anchor, visible): (ScrollAnchor, Vec<(usize, DisplayRow)>) = if pane.line_wrap {
+        wrap_window(
+            entries,
+            width,
+            MSG_CHAR_OFFSET,
+            cursor_idx,
+            effective_col,
+            height,
+            SCROLLOFF,
+            pane.scroll,
+        )
+    } else {
+        let mut scroll = pane.scroll.entry().min(entries.len().saturating_sub(1));
+        if cursor_idx < scroll + SCROLLOFF {
+            scroll = cursor_idx.saturating_sub(SCROLLOFF);
+        }
+        if cursor_idx + SCROLLOFF >= scroll + height {
+            scroll = (cursor_idx + SCROLLOFF + 1).saturating_sub(height);
+        }
+        scroll = scroll.min(entries.len().saturating_sub(height.min(entries.len())));
+        let rows = entries
+            .iter()
+            .enumerate()
+            .skip(scroll)
+            .take(height)
+            .map(|(idx, entry)| (idx, layout_entry(&row_text(entry), width, 0, false)[0]))
+            .collect();
+        (ScrollAnchor::Entry(scroll), rows)
+    };
+    pane.scroll = anchor;
 
     let matches = match &pane.view {
         View::Results { matches, .. } => Some(matches),
         View::Stream { .. } => None,
     };
 
+    // An entry can occupy several consecutive display rows; compute its full
+    // per-char style buffer once and slice each display row out of it.
     let mut lines: Vec<Line> = Vec::with_capacity(height);
-    for (offset, entry) in entries.iter().skip(scroll).take(height).enumerate() {
-        let idx = scroll + offset;
-        let is_cursor_row = idx == cursor_idx;
-        let width = content.width as usize;
-
-        let text = row_text(entry);
-        let chars: Vec<char> = text.chars().take(width).collect();
-        let level_style = Style::default().fg(theme.log_row_fg(entry.level));
-        let dim = Style::default().fg(theme.border_unfocused_fg);
-
-        // Base style per char: frame fields dimmed, level + msg in the
-        // row's level color.
-        let mut styles: Vec<Style> = (0..chars.len())
-            .map(|col| {
-                if (9..14).contains(&col) || col >= MSG_CHAR_OFFSET {
-                    level_style
-                } else {
-                    dim
-                }
-            })
-            .collect();
-
-        // Fuzzy match highlights (msg-relative char indices).
-        if let Some(entry_matches) = matches.and_then(|m| m.get(&entry.seq))
-            && let Some(msg_match) = entry_matches.iter().find(|m| m.key == "msg")
-        {
-            let hl = theme.match_style();
-            for &idx in &msg_match.indices {
-                let col = MSG_CHAR_OFFSET + idx as usize;
-                if col < styles.len() {
-                    styles[col] = styles[col].patch(hl);
-                }
-            }
+    let mut cached: Option<(usize, Vec<char>, Vec<Style>, Style)> = None;
+    for (entry_idx, drow) in visible {
+        if cached.as_ref().is_none_or(|c| c.0 != entry_idx) {
+            let entry = &entries[entry_idx];
+            let is_cursor_row = entry_idx == cursor_idx;
+            let (chars, styles, row_bg) = entry_row_styles(
+                entry,
+                pane,
+                theme,
+                focused,
+                mode,
+                matches,
+                is_cursor_row,
+                effective_col,
+            );
+            cached = Some((entry_idx, chars, styles, row_bg));
         }
-
-        // Visual selection (focused pane only).
-        let mut row_bg = Style::default();
-        if focused {
-            match mode {
-                Mode::Visual {
-                    anchor_seq,
-                    linewise: true,
-                    ..
-                } => {
-                    if let Some(cursor_seq) = pane.cursor_seq {
-                        let (lo, hi) = (anchor_seq.min(cursor_seq), anchor_seq.max(cursor_seq));
-                        if entry.seq >= lo && entry.seq <= hi {
-                            row_bg = Style::default().bg(theme.log_selected_bg);
-                        }
-                    }
-                }
-                Mode::Visual {
-                    anchor_seq,
-                    anchor_col,
-                    linewise: false,
-                } => {
-                    if let Some((from, to)) = pane.charwise_row_range(entry, anchor_seq, anchor_col)
-                    {
-                        let sel = Style::default().bg(theme.log_selected_bg);
-                        for style in styles.iter_mut().take((to + 1).min(chars.len())).skip(from) {
-                            *style = style.patch(sel);
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        // Cursorline tint and the block cursor cell.
-        if is_cursor_row && focused {
-            row_bg = theme.selected_style();
-            let col = pane.effective_col();
-            if col < styles.len() {
-                styles[col] = styles[col].add_modifier(Modifier::REVERSED);
-            }
-        } else if is_cursor_row {
-            row_bg = Style::default().add_modifier(Modifier::UNDERLINED);
-        }
-        if row_bg != Style::default() {
-            for style in &mut styles {
-                *style = row_bg.patch(*style);
-            }
-        }
-
-        lines.push(spans_from_styles(&chars, &styles, row_bg, width));
+        let (_, chars, styles, row_bg) = cached.as_ref().unwrap();
+        let start = drow.start_col.min(chars.len());
+        let end = drow.end_col.min(chars.len());
+        lines.push(spans_from_styles(
+            &chars[start..end],
+            &styles[start..end],
+            *row_bg,
+            drow.indent,
+            width,
+        ));
     }
     frame.render_widget(Paragraph::new(lines), content);
 }
 
-/// Group adjacent equal styles into spans; pad rows that carry a background
-/// to the full pane width so the tint spans the line.
+/// Build the full per-char style buffer for one entry's `row_text`.
+///
+/// Styles are indexed by logical char offset (not truncated to the pane width)
+/// so the wrap renderer can slice any display row out of them. The returned
+/// `row_bg` is the entry-wide cursorline/selection tint to pad each display row
+/// with. The block cursor's reversed cell is patched at `effective_col`; with
+/// wrap off, a column past the pane width stays out of the single visible slice
+/// (the pre-existing off-screen-cursor behavior, unchanged).
+#[allow(clippy::too_many_arguments)]
+fn entry_row_styles(
+    entry: &LogEntry,
+    pane: &Pane,
+    theme: &ThemeConfig,
+    focused: bool,
+    mode: Mode,
+    matches: Option<&HashMap<u64, Vec<Match>>>,
+    is_cursor_row: bool,
+    effective_col: usize,
+) -> (Vec<char>, Vec<Style>, Style) {
+    let chars: Vec<char> = row_text(entry).chars().collect();
+    let level_style = Style::default().fg(theme.log_row_fg(entry.level));
+    let dim = Style::default().fg(theme.border_unfocused_fg);
+
+    // Base style per char: frame fields dimmed, level + msg in the row's color.
+    let mut styles: Vec<Style> = (0..chars.len())
+        .map(|col| {
+            if (9..14).contains(&col) || col >= MSG_CHAR_OFFSET {
+                level_style
+            } else {
+                dim
+            }
+        })
+        .collect();
+
+    // Fuzzy match highlights (msg-relative char indices).
+    if let Some(entry_matches) = matches.and_then(|m| m.get(&entry.seq))
+        && let Some(msg_match) = entry_matches.iter().find(|m| m.key == "msg")
+    {
+        let hl = theme.match_style();
+        for &idx in &msg_match.indices {
+            let col = MSG_CHAR_OFFSET + idx as usize;
+            if col < styles.len() {
+                styles[col] = styles[col].patch(hl);
+            }
+        }
+    }
+
+    // Visual selection (focused pane only).
+    let mut row_bg = Style::default();
+    if focused {
+        match mode {
+            Mode::Visual {
+                anchor_seq,
+                linewise: true,
+                ..
+            } => {
+                if let Some(cursor_seq) = pane.cursor_seq {
+                    let (lo, hi) = (anchor_seq.min(cursor_seq), anchor_seq.max(cursor_seq));
+                    if entry.seq >= lo && entry.seq <= hi {
+                        row_bg = Style::default().bg(theme.log_selected_bg);
+                    }
+                }
+            }
+            Mode::Visual {
+                anchor_seq,
+                anchor_col,
+                linewise: false,
+            } => {
+                if let Some((from, to)) = pane.charwise_row_range(entry, anchor_seq, anchor_col) {
+                    let sel = Style::default().bg(theme.log_selected_bg);
+                    for style in styles.iter_mut().take((to + 1).min(chars.len())).skip(from) {
+                        *style = style.patch(sel);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Cursorline tint and the block cursor cell.
+    if is_cursor_row && focused {
+        row_bg = theme.selected_style();
+        if effective_col < styles.len() {
+            styles[effective_col] = styles[effective_col].add_modifier(Modifier::REVERSED);
+        }
+    } else if is_cursor_row {
+        row_bg = Style::default().add_modifier(Modifier::UNDERLINED);
+    }
+    if row_bg != Style::default() {
+        for style in &mut styles {
+            *style = row_bg.patch(*style);
+        }
+    }
+
+    (chars, styles, row_bg)
+}
+
+/// Lazily-laid-out wrap geometry over a pane's entries, memoized per entry so a
+/// giant entry is only wrapped once per frame even as the anchor walk revisits
+/// it.
+struct WrapCtx<'a> {
+    entries: &'a [Arc<LogEntry>],
+    width: usize,
+    indent: usize,
+    cache: HashMap<usize, Vec<DisplayRow>>,
+}
+
+impl WrapCtx<'_> {
+    fn rows(&mut self, entry: usize) -> &[DisplayRow] {
+        self.cache.entry(entry).or_insert_with(|| {
+            layout_entry(
+                &row_text(&self.entries[entry]),
+                self.width,
+                self.indent,
+                true,
+            )
+        })
+    }
+
+    fn len_at(&mut self, entry: usize) -> usize {
+        self.rows(entry).len()
+    }
+
+    /// One display row forward, crossing into the next entry at its first row.
+    fn step_fwd(&mut self, pos: (usize, usize)) -> Option<(usize, usize)> {
+        if pos.1 + 1 < self.len_at(pos.0) {
+            Some((pos.0, pos.1 + 1))
+        } else if pos.0 + 1 < self.entries.len() {
+            Some((pos.0 + 1, 0))
+        } else {
+            None
+        }
+    }
+
+    /// One display row back, crossing into the previous entry at its last row.
+    fn step_back(&mut self, pos: (usize, usize)) -> Option<(usize, usize)> {
+        if pos.1 > 0 {
+            Some((pos.0, pos.1 - 1))
+        } else if pos.0 > 0 {
+            Some((pos.0 - 1, self.len_at(pos.0 - 1) - 1))
+        } else {
+            None
+        }
+    }
+}
+
+/// Wrap-on scroll: keep the cursor's *display row* on screen while measuring
+/// scroll in display rows. Anchored on `(entry_index, display_row)` rather than
+/// a global row count (which would be circular), with a bounded backward walk
+/// from the previous anchor. Returns the new anchor plus the ordered visible
+/// `(entry_index, display_row)` pairs filling the viewport.
+#[allow(clippy::too_many_arguments)]
+fn wrap_window(
+    entries: &[Arc<LogEntry>],
+    width: usize,
+    indent: usize,
+    cursor_idx: usize,
+    cursor_col: usize,
+    height: usize,
+    scrolloff: usize,
+    prev: ScrollAnchor,
+) -> (ScrollAnchor, Vec<(usize, DisplayRow)>) {
+    let mut ctx = WrapCtx {
+        entries,
+        width,
+        indent,
+        cache: HashMap::new(),
+    };
+
+    let cur_disp = col_to_display(ctx.rows(cursor_idx), cursor_col).0;
+    let cursor_pos = (cursor_idx, cur_disp);
+
+    // Normalize the previous anchor into a valid (entry, row) for this mode.
+    let mut top = match prev {
+        ScrollAnchor::Display { entry, row } => {
+            let entry = entry.min(entries.len() - 1);
+            (entry, row.min(ctx.len_at(entry).saturating_sub(1)))
+        }
+        ScrollAnchor::Entry(entry) => (entry.min(entries.len() - 1), 0),
+    };
+
+    // Bound the backward walk: an anchor more than a viewport of entries above
+    // the cursor is stale (every entry is at least one display row), snap near.
+    if cursor_idx > top.0 + height + 1 {
+        top = (cursor_idx, 0);
+    }
+    // The anchor must never sit below the cursor.
+    if top > cursor_pos {
+        top = cursor_pos;
+    }
+
+    // Display-row distance from the anchor down to the cursor.
+    let mut dist = 0usize;
+    let mut walk = top;
+    while walk != cursor_pos {
+        walk = ctx
+            .step_fwd(walk)
+            .expect("cursor is at or below the anchor by construction");
+        dist += 1;
+    }
+
+    // Bottom scrolloff: if the cursor sits too low, scroll down (anchor moves
+    // forward) until it is within `height - 1 - scrolloff` of the top.
+    let max_below = height.saturating_sub(1).saturating_sub(scrolloff);
+    while dist > max_below {
+        top = ctx
+            .step_fwd(top)
+            .expect("a lower cursor leaves room to advance");
+        dist -= 1;
+    }
+    // Top scrolloff: keep context above the cursor when any exists.
+    while dist < scrolloff {
+        match ctx.step_back(top) {
+            Some(prev_top) => {
+                top = prev_top;
+                dist += 1;
+            }
+            None => break,
+        }
+    }
+    // Avoid blank space at the bottom: when fewer than `height` rows remain
+    // below the anchor, pull it back to fill (mirrors the entry-scroll clamp).
+    let mut avail = 1usize;
+    let mut probe = top;
+    while avail < height {
+        match ctx.step_fwd(probe) {
+            Some(next) => {
+                probe = next;
+                avail += 1;
+            }
+            None => break,
+        }
+    }
+    let mut deficit = height.saturating_sub(avail);
+    while deficit > 0 {
+        match ctx.step_back(top) {
+            Some(prev_top) => {
+                top = prev_top;
+                deficit -= 1;
+            }
+            None => break,
+        }
+    }
+
+    // Emit visible display rows from the anchor forward.
+    let mut out = Vec::with_capacity(height);
+    let mut pos = top;
+    loop {
+        let row = ctx.rows(pos.0)[pos.1];
+        out.push((pos.0, row));
+        if out.len() == height {
+            break;
+        }
+        match ctx.step_fwd(pos) {
+            Some(next) => pos = next,
+            None => break,
+        }
+    }
+
+    (
+        ScrollAnchor::Display {
+            entry: top.0,
+            row: top.1,
+        },
+        out,
+    )
+}
+
+/// Group adjacent equal styles into spans, prefixed by the row's hanging indent
+/// and padded to the full pane width when the row carries a background, so the
+/// cursorline/selection tint spans the whole display row (indent included).
 fn spans_from_styles(
     chars: &[char],
     styles: &[Style],
     row_bg: Style,
+    indent: usize,
     width: usize,
 ) -> Line<'static> {
     let mut spans: Vec<Span<'static>> = Vec::new();
+    if indent > 0 {
+        spans.push(Span::styled(" ".repeat(indent), row_bg));
+    }
     let mut run = String::new();
     let mut run_style = styles.first().copied().unwrap_or_default();
     for (c, style) in chars.iter().zip(styles) {
@@ -347,8 +595,9 @@ fn spans_from_styles(
     if !run.is_empty() {
         spans.push(Span::styled(run, run_style));
     }
-    if row_bg != Style::default() && chars.len() < width {
-        spans.push(Span::styled(" ".repeat(width - chars.len()), row_bg));
+    let used = indent + chars.len();
+    if row_bg != Style::default() && used < width {
+        spans.push(Span::styled(" ".repeat(width - used), row_bg));
     }
     Line::from(spans)
 }
@@ -544,6 +793,7 @@ const HELP_TEXT: &str = "\
   n N            next / previous hit (first jump freezes)
   v V            visual chars / lines · y yanks
   y              yank entry as JSON
+  W              toggle line wrap (:wrap · :set wrap/nowrap)
   Enter          results: open in context
                  stream: entry detail
   Esc            leave results / clear
@@ -583,4 +833,264 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect, theme: &ThemeConfig) {
             .block(block),
         rect,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use chrono::DateTime;
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+
+    use super::*;
+    use crate::{
+        event::{Match, PaneId},
+        log::{LogLevel, Source},
+        tui::pane::View,
+    };
+
+    const W: u16 = 40;
+    const INDENT: usize = MSG_CHAR_OFFSET;
+
+    fn entry(seq: u64, msg: &str) -> Arc<LogEntry> {
+        Arc::new(LogEntry {
+            seq,
+            msg: msg.to_string(),
+            // Fixed 00:00:00 timestamp so row_text is deterministic.
+            ts: DateTime::from_timestamp(0, 0).unwrap(),
+            level: Some(LogLevel::Info),
+            source: Source {
+                producer: "p".to_string(),
+                id: "s".to_string(),
+                display_name: "src".to_string(),
+                group: None,
+            },
+            fields: HashMap::new(),
+        })
+    }
+
+    fn stream_pane(entries: Vec<Arc<LogEntry>>, cursor: u64) -> Pane {
+        let mut pane = Pane::new(PaneId(1));
+        pane.follow = false;
+        pane.cursor_seq = Some(cursor);
+        pane.view = View::Stream { entries };
+        pane
+    }
+
+    fn render(pane: &mut Pane, h: u16, focused: bool, mode: Mode) -> Buffer {
+        let backend = TestBackend::new(W, h);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = ThemeConfig::default();
+        let stats = StoreStats {
+            retained: 1,
+            capacity: 100,
+            bounds: (1, 99),
+        };
+        terminal
+            .draw(|frame| draw_pane(pane, frame, frame.area(), &theme, focused, mode, stats))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn row_string(buf: &Buffer, y: u16) -> String {
+        (buf.area.left()..buf.area.right())
+            .map(|x| buf.cell((x, y)).unwrap().symbol())
+            .collect()
+    }
+
+    // ---- D2: wrap-off golden gate -------------------------------------
+
+    #[test]
+    fn wrap_off_renders_single_truncated_row_byte_for_byte() {
+        let e = entry(1, "hello world this message is far longer than forty cols");
+        let mut pane = stream_pane(vec![e.clone()], 1);
+        let buf = render(&mut pane, 5, true, Mode::Normal);
+
+        let expected: String = row_text(&e).chars().take(W as usize).collect();
+        assert_eq!(row_string(&buf, 0).trim_end(), expected.trim_end());
+        // No wrapping: the second content row stays empty.
+        assert_eq!(row_string(&buf, 1).trim_end(), "");
+    }
+
+    // ---- D2: wrap-on layout -------------------------------------------
+
+    #[test]
+    fn wrap_on_continuation_has_hanging_indent_and_no_frame() {
+        let e = entry(1, "abcdefghijklmnopqrstuvwxyz0123456789");
+        let rows = layout_entry(&row_text(&e), W as usize, INDENT, true);
+        assert!(rows.len() >= 2, "entry must wrap for this test");
+
+        let mut pane = stream_pane(vec![e.clone()], 1);
+        pane.line_wrap = true;
+        let buf = render(&mut pane, 6, false, Mode::Normal);
+
+        let text: Vec<char> = row_text(&e).chars().collect();
+        // First row carries the timestamp frame.
+        assert!(row_string(&buf, 0).starts_with("00:00:00"));
+        // Continuation row: indent spaces, then the next logical slice.
+        let cont = &rows[1];
+        let line1 = row_string(&buf, 1);
+        assert_eq!(&line1[..INDENT], &" ".repeat(INDENT));
+        let expected_slice: String = text[cont.start_col..cont.end_col].iter().collect();
+        assert!(line1[INDENT..].starts_with(&expected_slice));
+    }
+
+    #[test]
+    fn wrap_on_cursor_lands_on_continuation_display_row() {
+        let e = entry(1, "abcdefghijklmnopqrstuvwxyz0123456789");
+        let mut pane = stream_pane(vec![e.clone()], 1);
+        pane.line_wrap = true;
+        // A column in the second display row.
+        pane.cursor_col = 45;
+        let rows = layout_entry(&row_text(&e), W as usize, INDENT, true);
+        let (r, c) = col_to_display(&rows, 45);
+        assert_eq!(r, 1, "col 45 should fall on the first continuation row");
+
+        let buf = render(&mut pane, 6, true, Mode::Normal);
+        let cell = buf.cell((c as u16, r as u16)).unwrap();
+        assert!(
+            cell.modifier.contains(Modifier::REVERSED),
+            "block cursor cell should be reversed on the continuation row"
+        );
+    }
+
+    #[test]
+    fn wrap_on_fuzzy_highlight_maps_to_continuation_row() {
+        let e = entry(1, "abcdefghijklmnopqrstuvwxyz0123456789");
+        let mut matches: HashMap<u64, Vec<Match>> = HashMap::new();
+        // msg index 20 → logical col MSG_CHAR_OFFSET + 20, on a continuation row.
+        matches.insert(
+            1,
+            vec![Match {
+                key: "msg".to_string(),
+                indices: vec![20],
+            }],
+        );
+        let mut pane = stream_pane(vec![e.clone()], 1);
+        pane.line_wrap = true;
+        pane.view = View::Results {
+            entries: vec![e.clone()],
+            matches,
+            progress: None,
+            term: "x".to_string(),
+        };
+
+        let rows = layout_entry(&row_text(&e), W as usize, INDENT, true);
+        let (r, c) = col_to_display(&rows, MSG_CHAR_OFFSET + 20);
+        assert!(r >= 1, "match should land on a continuation row");
+
+        let buf = render(&mut pane, 6, false, Mode::Normal);
+        let theme = ThemeConfig::default();
+        if let Some(fg) = theme.match_style().fg {
+            assert_eq!(buf.cell((c as u16, r as u16)).unwrap().fg, fg);
+        }
+    }
+
+    #[test]
+    fn wrap_on_charwise_tint_spans_wrap_boundary() {
+        let theme = ThemeConfig::default();
+        let e1 = entry(1, "abcdefghijklmnopqrstuvwxyz0123456789");
+        let e2 = entry(2, "short");
+        let mut pane = stream_pane(vec![e1.clone(), e2.clone()], 2);
+        pane.line_wrap = true;
+        pane.cursor_col = 5;
+        // Selection from (e1, col 35) down into e2 — e1 is the start entry, so
+        // its tint runs col 35..end across the wrap boundary.
+        let mode = Mode::Visual {
+            anchor_seq: 1,
+            anchor_col: 35,
+            linewise: false,
+        };
+        let buf = render(&mut pane, 8, true, mode);
+
+        // col 38 is on the first display row; logical col 43 on the second.
+        assert_eq!(buf.cell((38, 0)).unwrap().bg, theme.log_selected_bg);
+        let rows = layout_entry(&row_text(&e1), W as usize, INDENT, true);
+        let (r, c) = col_to_display(&rows, 43);
+        assert_eq!(
+            buf.cell((c as u16, r as u16)).unwrap().bg,
+            theme.log_selected_bg
+        );
+        // A column before the selection start is not tinted.
+        assert_ne!(buf.cell((30, 0)).unwrap().bg, theme.log_selected_bg);
+    }
+
+    #[test]
+    fn wrap_on_linewise_tint_pads_full_rows_including_indent() {
+        let theme = ThemeConfig::default();
+        let e = entry(1, "abcdefghijklmnopqrstuvwxyz0123456789");
+        let rows = layout_entry(&row_text(&e), W as usize, INDENT, true);
+        let mut pane = stream_pane(vec![e.clone()], 1);
+        pane.line_wrap = true;
+        let mode = Mode::Visual {
+            anchor_seq: 1,
+            anchor_col: 0,
+            linewise: true,
+        };
+        let buf = render(&mut pane, 8, true, mode);
+
+        // Every display row of the entry is tinted across the full width,
+        // including the hanging-indent gap and trailing padding.
+        for y in 0..rows.len() as u16 {
+            for x in 0..W {
+                assert_eq!(
+                    buf.cell((x, y)).unwrap().bg,
+                    theme.log_selected_bg,
+                    "cell ({x},{y}) should carry the selection background"
+                );
+            }
+        }
+    }
+
+    // ---- D3: wrap-aware scroll ----------------------------------------
+
+    #[test]
+    fn wrap_on_tall_entry_keeps_cursor_display_row_visible() {
+        // One entry taller than the viewport.
+        let long: String = "abcdefghij".repeat(20); // 200 chars
+        let e = entry(1, &long);
+        let mut pane = stream_pane(vec![e], 1);
+        pane.line_wrap = true;
+
+        // Cursor parked at the end → the last display row must be on screen.
+        pane.cursor_col = usize::MAX;
+        let buf = render(&mut pane, 5, true, Mode::Normal);
+        let reversed = (0..buf.area.height)
+            .flat_map(|y| (0..W).map(move |x| (x, y)))
+            .any(|(x, y)| {
+                buf.cell((x, y))
+                    .unwrap()
+                    .modifier
+                    .contains(Modifier::REVERSED)
+            });
+        assert!(reversed, "cursor on the last display row must be visible");
+
+        // Cursor at the start → the first display row (with the frame) shows.
+        pane.cursor_col = 0;
+        let buf = render(&mut pane, 5, true, Mode::Normal);
+        assert!(row_string(&buf, 0).starts_with("00:00:00"));
+        assert!(
+            buf.cell((0, 0))
+                .unwrap()
+                .modifier
+                .contains(Modifier::REVERSED)
+        );
+    }
+
+    #[test]
+    fn wrap_off_scroll_keeps_cursor_visible() {
+        let entries: Vec<_> = (1..=20).map(|s| entry(s, "msg")).collect();
+        let mut pane = stream_pane(entries, 10);
+        // Wrap off, cursor in the middle: it must remain rendered.
+        let buf = render(&mut pane, 6, true, Mode::Normal);
+        let reversed = (0..buf.area.height)
+            .flat_map(|y| (0..W).map(move |x| (x, y)))
+            .any(|(x, y)| {
+                buf.cell((x, y))
+                    .unwrap()
+                    .modifier
+                    .contains(Modifier::REVERSED)
+            });
+        assert!(reversed, "cursor entry should stay on screen with wrap off");
+    }
 }

--- a/fml/src/tui/workspace.rs
+++ b/fml/src/tui/workspace.rs
@@ -356,8 +356,11 @@ pub struct Workspace {
 }
 
 impl Workspace {
-    pub fn new() -> Self {
-        let pane = Pane::new(PaneId(1));
+    /// Build a workspace whose initial pane starts at the configured wrap
+    /// default. Splits and new tabs inherit/seed from there.
+    pub fn new(line_wrap: bool) -> Self {
+        let mut pane = Pane::new(PaneId(1));
+        pane.line_wrap = line_wrap;
         Self {
             tabs: vec![Tab::new("main".to_string(), pane)],
             active_tab: 0,
@@ -455,10 +458,12 @@ impl Workspace {
 
     /// Create a new tab with a fresh tailing pane and focus it.
     /// Returns the new pane id for dispatch.
-    pub fn new_tab(&mut self, name: Option<String>) -> PaneId {
+    pub fn new_tab(&mut self, name: Option<String>, line_wrap: bool) -> PaneId {
         let id = self.alloc_pane_id();
         let name = name.unwrap_or_else(|| format!("tab {}", self.tabs.len() + 1));
-        self.tabs.push(Tab::new(name, Pane::new(id)));
+        let mut pane = Pane::new(id);
+        pane.line_wrap = line_wrap;
+        self.tabs.push(Tab::new(name, pane));
         self.active_tab = self.tabs.len() - 1;
         id
     }
@@ -487,7 +492,7 @@ impl Workspace {
 
 impl Default for Workspace {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
@@ -497,7 +502,7 @@ mod tests {
 
     #[test]
     fn split_same_axis_extends_instead_of_nesting() {
-        let mut ws = Workspace::new();
+        let mut ws = Workspace::new(false);
         ws.split(Direction::Horizontal);
         ws.split(Direction::Horizontal);
 
@@ -513,7 +518,7 @@ mod tests {
 
     #[test]
     fn split_other_axis_nests_under_focused_leaf() {
-        let mut ws = Workspace::new();
+        let mut ws = Workspace::new(false);
         ws.split(Direction::Horizontal);
         ws.split(Direction::Vertical);
 
@@ -536,7 +541,7 @@ mod tests {
 
     #[test]
     fn split_clones_focused_pane_filter() {
-        let mut ws = Workspace::new();
+        let mut ws = Workspace::new(false);
         ws.focused_pane_mut().filter = vec!["api".to_string()];
 
         let new_id = ws.split(Direction::Horizontal);
@@ -547,8 +552,31 @@ mod tests {
     }
 
     #[test]
+    fn startup_default_seeds_initial_pane_wrap() {
+        let ws = Workspace::new(true);
+        assert!(ws.focused_pane().line_wrap);
+    }
+
+    #[test]
+    fn split_inherits_wrap_state_of_source_pane() {
+        let mut ws = Workspace::new(false);
+        ws.focused_pane_mut().line_wrap = true;
+
+        ws.split(Direction::Horizontal);
+
+        assert!(ws.focused_pane().line_wrap, "split inherits the wrap flag");
+    }
+
+    #[test]
+    fn new_tab_seeds_wrap_from_config_default() {
+        let mut ws = Workspace::new(false);
+        ws.new_tab(Some("wrapped".to_string()), true);
+        assert!(ws.focused_pane().line_wrap);
+    }
+
+    #[test]
     fn close_collapses_split_and_last_pane_closes_tab() {
-        let mut ws = Workspace::new();
+        let mut ws = Workspace::new(false);
         ws.split(Direction::Horizontal);
 
         let (closed, empty) = ws.close_focused_pane();
@@ -563,7 +591,7 @@ mod tests {
 
     #[test]
     fn only_keeps_focused_pane() {
-        let mut ws = Workspace::new();
+        let mut ws = Workspace::new(false);
         ws.split(Direction::Horizontal);
         ws.split(Direction::Vertical);
         let focused = ws.tab().focused;
@@ -578,8 +606,8 @@ mod tests {
 
     #[test]
     fn tabs_cycle_and_close() {
-        let mut ws = Workspace::new();
-        ws.new_tab(Some("errors".to_string()));
+        let mut ws = Workspace::new(false);
+        ws.new_tab(Some("errors".to_string()), false);
         assert_eq!(ws.active_tab, 1);
         assert_eq!(ws.tab().name, "errors");
 
@@ -596,7 +624,7 @@ mod tests {
 
     #[test]
     fn directional_focus_uses_rendered_rects() {
-        let mut ws = Workspace::new();
+        let mut ws = Workspace::new(false);
         let right = ws.split(Direction::Horizontal);
         let left = PaneId(1);
         ws.tab_mut().pane_mut(left).unwrap().rect = Rect::new(0, 0, 40, 20);
@@ -613,7 +641,7 @@ mod tests {
 
     #[test]
     fn layout_splits_area_evenly_with_vsplit_gutter() {
-        let mut ws = Workspace::new();
+        let mut ws = Workspace::new(false);
         ws.split(Direction::Horizontal);
         let mut rects = Vec::new();
         let mut gutters = Vec::new();
@@ -631,7 +659,7 @@ mod tests {
 
     #[test]
     fn stacked_layout_has_no_gutters() {
-        let mut ws = Workspace::new();
+        let mut ws = Workspace::new(false);
         ws.split(Direction::Vertical);
         let mut rects = Vec::new();
         let mut gutters = Vec::new();


### PR DESCRIPTION
## Why

The modal-vim rework rebuilt the log view on a strict one-entry-one-row model: `row_text(entry)` was truncated with `.chars().take(width)`. Long log entries were clipped at the pane edge with no way to see the rest without the detail overlay. This reintroduces line wrapping as a per-pane toggle so long messages can be read in place.

Implements `docs/plans/linewrap-bigplan.md`.

## What

- **Per-pane wrap toggle** via `:wrap`, `:set wrap` / `:set nowrap`, and a hardcoded `W` key (`w` stays word-forward). Off by default; truncation behavior is unchanged.
- **Startup default** from `TuiConfig.line_wrap`, seeded into each pane through `Workspace::new`/`new_tab` and inherited on split via `clone_into`. The advisory `toggle_line_wrap` keybinding field is documented as not-yet-wired (the whole `KeybindingsConfig` is unwired), with its default corrected to `W`.
- **Pure layout primitive** (`fml/src/tui/layout.rs`): `layout_entry` (greedy char-wrap, hanging indent aligned under the message column, narrow-pane saturation) and `col_to_display` — the single source of truth for display geometry, exhaustively unit-tested.
- **Wrapped rendering** (`draw_pane`): a display-row loop driven by the primitive; frame drawn only on each entry's first row, hanging indent on continuations, per-char styles (base/level, fuzzy highlight, charwise/linewise tint, block cursor) mapped onto the correct display row, full-width background padding.
- **Wrap-aware scroll**: a typed `ScrollAnchor` that distinguishes entry-index (wrap off) from `(entry, display_row)` (wrap on), with a bounded backward/forward fill so the cursor's display row stays visible, including entries taller than the viewport. `goto_bottom`/`enter_follow` park the cursor at line end (wrap-on only) so tail lands on the newest entry's last display row.

## Scope / decisions

- Navigation stays **entry/logical-based** — `j`/`k`, paging, and all column motions (`0`/`$`/`h`/`l`/`w`/`b`) are unchanged; only rendering and render-time scroll became wrap-aware. (The visual-navigation option was deliberately dropped — see the plan's Issues log.)
- Wrapping is greedy char-wrap on Rust `char` offsets; **not** grapheme/terminal-cell aware (wide chars/emoji may misalign), matching the existing truncation/yank model. A test locks this behavior.
- Detail overlay and configurable keybindings are out of scope.

## Verification

- `cargo test` — 341 lib tests pass (was 323; +18 covering layout math, golden wrap-off rendering, hanging indent, cursor placement, fuzzy/charwise/linewise highlight mapping, tall-entry scroll, toggle wiring, config seeding, split inheritance, and yank fidelity across a wrap boundary). Pre-commit hook ran build/test/fmt/clippy on the commit.
- `cargo clippy --all-targets` — no new warnings in changed files.
- Live smoke test (zellij + `--producer demo`): toggling `W` on one pane of a vsplit wrapped long entries with the hanging indent aligned under the message column while the other pane stayed truncated (per-pane); `:set nowrap` reverted it.

## Review focus

- **Wrap-off byte-for-byte**: `draw_pane` now routes both modes through the layout primitive. A golden TestBackend test (`wrap_off_renders_single_truncated_row_byte_for_byte`) pins the unchanged truncated output, including the pre-existing off-screen cursor quirk when `cursor_col >= width`.
- **`wrap_window` anchor math** (`render.rs`): the backward walk is bounded and the layout is memoized per entry, but a single pathological entry far taller than the viewport is the accepted giant-entry cost per the plan.
- **`snap_col_to_row_end`** parks `cursor_col` at `usize::MAX` (clamped by `effective_col`) only when wrap is on, so wrap-off cursor placement is untouched.
- `docs/plans/` is intentionally untracked (a prior commit removed plans from the repo), so the plan doc is not included here.
